### PR TITLE
Move the 'findFiles' utility into `src` so that it gets correctly processed with babel

### DIFF
--- a/.changeset/honest-lamps-scream.md
+++ b/.changeset/honest-lamps-scream.md
@@ -1,0 +1,5 @@
+---
+'@khanacademy/graphql-flow': patch
+---
+
+Fix transpilation of the find-files-with-gql utility

--- a/src/find-files-with-gql.js
+++ b/src/find-files-with-gql.js
@@ -17,10 +17,13 @@ export const findRepoRoot = (): string => {
     }
 };
 
-export const findGraphqlTagReferences = (root: string): Array<string> => {
+export const findGraphqlTagReferences = (
+    root: string,
+    needle: string = 'gql`',
+): Array<string> => {
     try {
         const response = execSync(
-            "git grep -I --word-regexp --name-only --fixed-strings 'gql`' -- '*.js'",
+            `git grep -I --word-regexp --name-only --fixed-strings '${needle}' -- '*.js'`,
             {
                 encoding: 'utf8',
                 cwd: root,


### PR DESCRIPTION
## Summary:
an oversight while I was getting the build setup together

Issue: https://khanacademy.atlassian.net/browse/FEI-4336

## Test plan:
`yarn run build`, see that `find-files-with-gql.js` gets transpiled!