### PR TITLE
Support inline fragments on objects

### DIFF
--- a/.changeset/moody-points-happen.md
+++ b/.changeset/moody-points-happen.md
@@ -1,0 +1,5 @@
+---
+'@khanacademy/graphql-flow': patch
+---
+
+Support inline fragments on objects

--- a/src/__test__/graphql-flow.test.js
+++ b/src/__test__/graphql-flow.test.js
@@ -342,6 +342,67 @@ describe('graphql-flow generation', () => {
             `);
         });
 
+        it('should handle an inline fragment on an interface without a typeCondition', () => {
+            const result = rawQueryToFlowTypes(
+                `
+                query SomeQuery {
+                    hero(episode: JEDI) {
+                        id
+                        ... {
+                            name
+                        }
+                    }
+                }`,
+                {readOnlyArray: false},
+            );
+            expect(result).toMatchInlineSnapshot(`
+                export type SomeQueryType = {|
+                    variables: {||},
+                    response: {|
+                  hero: ?({|
+                    id: string,
+
+                    /** The person's name*/
+                    name: ?string,
+                  |} | {|
+                    id: string,
+                    name: ?string,
+                  |})
+                |}
+                |};
+            `);
+        });
+
+        it('should handle an inline fragment on an object (not an interface)', () => {
+            const result = rawQueryToFlowTypes(
+                `
+                query SomeQuery {
+                    human(id: "hi") {
+                        id
+                        ... {
+                            name
+                        }
+                    }
+                }`,
+                {readOnlyArray: false},
+            );
+            expect(result).toMatchInlineSnapshot(`
+                export type SomeQueryType = {|
+                    variables: {||},
+                    response: {|
+
+                  /** A human character*/
+                  human: ?{|
+                    id: string,
+
+                    /** The person's name*/
+                    name: ?string,
+                  |}
+                |}
+                |};
+            `);
+        });
+
         it('should handle a complex input variable', () => {
             const result = rawQueryToFlowTypes(
                 `mutation addCharacter($character: CharacterInput!) {

--- a/src/generateResponseType.js
+++ b/src/generateResponseType.js
@@ -175,6 +175,14 @@ export const objectPropertiesToFlow = (
     return [].concat(
         ...selections.map((selection) => {
             switch (selection.kind) {
+                case 'InlineFragment': {
+                    return objectPropertiesToFlow(
+                        config,
+                        type,
+                        typeName,
+                        selection.selectionSet.selections,
+                    );
+                }
                 case 'FragmentSpread':
                     if (!config.fragments[selection.name.value]) {
                         config.errors.push(
@@ -397,23 +405,20 @@ Try using an inline fragment "... on SomeType {}".`);
         }
         return [];
     }
-    if (!selection.typeCondition) {
-        throw new Error('Expected selection to have a typeCondition');
-    }
-    const typeName = selection.typeCondition.name.value;
-    if (
-        (config.schema.interfacesByName[typeName] &&
-            config.schema.interfacesByName[typeName].possibleTypesByName[
+    if (selection.typeCondition) {
+        const typeName = selection.typeCondition.name.value;
+        const indirectMatch =
+            config.schema.interfacesByName[typeName]?.possibleTypesByName[
                 possible.name
-            ]) ||
-        typeName === possible.name
-    ) {
-        return objectPropertiesToFlow(
-            config,
-            config.schema.typesByName[possible.name],
-            possible.name,
-            selection.selectionSet.selections,
-        );
+            ];
+        if (typeName !== possible.name && !indirectMatch) {
+            return [];
+        }
     }
-    return [];
+    return objectPropertiesToFlow(
+        config,
+        config.schema.typesByName[possible.name],
+        possible.name,
+        selection.selectionSet.selections,
+    );
 };

--- a/src/generateResponseType.js
+++ b/src/generateResponseType.js
@@ -254,6 +254,7 @@ export const objectPropertiesToFlow = (
 
                 default:
                     config.errors.push(
+                        // eslint-disable-next-line flowtype-errors/uncovered
                         `Unsupported selection kind '${selection.kind}'`,
                     );
                     return [];


### PR DESCRIPTION
## Summary:
Looks like we use these in webapp, so we need to support them!
Also added support for an inline fragment on an interface without a type condition, because that's possible to do.

Issue: none

## Test plan:
See tests!