### PR TITLE
Add 'ignorePragma' option, to allow skipping of documents

### DIFF
--- a/.changeset/nine-seals-invent.md
+++ b/.changeset/nine-seals-invent.md
@@ -1,0 +1,5 @@
+---
+'@khanacademy/graphql-flow': patch
+---
+
+Add 'ignorePragma' option, to allow skipping of documents

--- a/Readme.md
+++ b/Readme.md
@@ -145,6 +145,9 @@ And then `yarn generate-types` or `npm run generate-types` gets your types gener
     loosePragma?: string,
     // If neither pragma nor loosePragma are specified, all graphql documents
     // that contain a query or mutation will be processed.
+
+    // Any graphql operations containing ignorePragma will be skipped
+    ignorePragma?: string,
 }
 ```
 

--- a/src/__test__/jest-mock-graphql-tag.test.js
+++ b/src/__test__/jest-mock-graphql-tag.test.js
@@ -48,4 +48,16 @@ describe('processPragmas', () => {
             scalars: undefined,
         });
     });
+
+    it('should reject query with ignore pragma', () => {
+        expect(
+            processPragmas(
+                {ignorePragma: '# @ignore\n'},
+                `query X {
+                    # @ignore
+                    Y
+                }`,
+            ),
+        ).toEqual(null);
+    });
 });

--- a/src/jest-mock-graphql-tag.js
+++ b/src/jest-mock-graphql-tag.js
@@ -105,6 +105,7 @@ type GraphqlTagFn = (raw: string, ...args: Array<any>) => DocumentNode;
 type SpyOptions = {
     pragma?: string,
     loosePragma?: string,
+    ignorePragma?: string,
     scalars?: Scalars,
     strictNullability?: boolean,
     /**
@@ -133,6 +134,9 @@ type SpyOptions = {
  * If both pragma and loosePragma are empty, then all graphql
  * documents will be processed. Otherwise, only documents
  * with one of the pragmas will be processed.
+ * Any operations containing `ignorePragma` (if provided)
+ * will be skipped, regardless of whether they contain
+ * another specified pragma.
  */
 const spyOnGraphqlTagToCollectQueries = (
     realGraphqlTag: GraphqlTagFn,
@@ -176,6 +180,10 @@ const processPragmas = (
     options: SpyOptions,
     rawSource: string,
 ): null | Options => {
+    if (options.ignorePragma && rawSource.includes(options.ignorePragma)) {
+        return null;
+    }
+
     const autogen = options.loosePragma
         ? rawSource.includes(options.loosePragma)
         : false;


### PR DESCRIPTION
## Summary:
The queries in the khan-library package need to be ignored because they target a different schema.

Issue: XXX-XXXX

## Test plan:
Checks!