### PR TITLE
Add 'dumpOperations' config option, to enable safelisting

### DIFF
--- a/.changeset/spotty-ravens-drop.md
+++ b/.changeset/spotty-ravens-drop.md
@@ -1,0 +1,5 @@
+---
+'@khanacademy/graphql-flow': patch
+---
+
+Add 'dumpOperations' config option, to enable safelisting

--- a/src/cli/config.js
+++ b/src/cli/config.js
@@ -36,7 +36,12 @@ type JSONConfig = {
 export const loadConfigFile = (configFile: string): CliConfig => {
     // eslint-disable-next-line flowtype-errors/uncovered
     const data: JSONConfig = JSON.parse(fs.readFileSync(configFile, 'utf8'));
-    const toplevelKeys = ['excludes', 'schemaFilePath', 'options'];
+    const toplevelKeys = [
+        'excludes',
+        'schemaFilePath',
+        'options',
+        'dumpOperations',
+    ];
     Object.keys(data).forEach((k) => {
         if (!toplevelKeys.includes(k)) {
             throw new Error(

--- a/src/cli/config.js
+++ b/src/cli/config.js
@@ -18,6 +18,7 @@ import path from 'path';
 export type CliConfig = {
     excludes: Array<RegExp>,
     schemaFilePath: string,
+    dumpOperations?: string,
     options: ExternalOptions,
 };
 
@@ -29,6 +30,7 @@ type JSONConfig = {
     excludes?: Array<string>,
     schemaFilePath: string,
     options?: ExternalOptions,
+    dumpOperations?: string,
 };
 
 export const loadConfigFile = (configFile: string): CliConfig => {
@@ -75,6 +77,7 @@ export const loadConfigFile = (configFile: string): CliConfig => {
             path.dirname(configFile),
             data.schemaFilePath,
         ),
+        dumpOperations: data.dumpOperations,
     };
 };
 

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -9,7 +9,7 @@ import {getSchemas, loadConfigFile} from './config';
 import {addTypenameToDocument} from 'apollo-utilities'; // eslint-disable-line flowtype-errors/uncovered
 
 import {execSync} from 'child_process';
-import {existsSync, mkdir, readFileSync, writeFileSync} from 'fs';
+import {existsSync, mkdir, mkdirSync, readFileSync, writeFileSync} from 'fs';
 import {type DocumentNode} from 'graphql';
 import {print} from 'graphql/language/printer';
 import {validate} from 'graphql/validation';
@@ -181,9 +181,7 @@ if (validationFailures) {
 if (config.dumpOperations) {
     const dumpOperations = config.dumpOperations;
     const parent = dirname(dumpOperations);
-    if (!existsSync(parent)) {
-        mkdir(parent, {recursive: true});
-    }
+    mkdirSync(parent, {recursive: true});
     writeFileSync(
         dumpOperations,
         JSON.stringify(printedOperations.sort(), null, 2),

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -123,15 +123,18 @@ Object.keys(resolved).forEach((k) => {
         ({kind}) => kind !== 'FragmentDefinition',
     );
     const rawSource: string = raw.literals[0];
-    const processedOptions = processPragmas(config.options, rawSource);
-    if (!processedOptions) {
-        return;
-    }
 
     // eslint-disable-next-line flowtype-errors/uncovered
     const withTypeNames: DocumentNode = addTypenameToDocument(document);
     const printed = print(withTypeNames);
-    printedOperations.push(printed);
+    if (hasNonFragments && !printedOperations.includes(printed)) {
+        printedOperations.push(printed);
+    }
+
+    const processedOptions = processPragmas(config.options, rawSource);
+    if (!processedOptions) {
+        return;
+    }
 
     if (hasNonFragments) {
         /* eslint-disable flowtype-errors/uncovered */
@@ -181,5 +184,5 @@ if (config.dumpOperations) {
     if (!existsSync(parent)) {
         mkdir(parent, {recursive: true});
     }
-    writeFileSync(dumpOperations, JSON.stringify(printedOperations));
+    writeFileSync(dumpOperations, JSON.stringify(printedOperations.sort()));
 }

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -184,5 +184,8 @@ if (config.dumpOperations) {
     if (!existsSync(parent)) {
         mkdir(parent, {recursive: true});
     }
-    writeFileSync(dumpOperations, JSON.stringify(printedOperations.sort()));
+    writeFileSync(
+        dumpOperations,
+        JSON.stringify(printedOperations.sort(), null, 2),
+    );
 }

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -9,7 +9,7 @@ import {getSchemas, loadConfigFile} from './config';
 import {addTypenameToDocument} from 'apollo-utilities'; // eslint-disable-line flowtype-errors/uncovered
 
 import {execSync} from 'child_process';
-import {existsSync, mkdir, mkdirSync, readFileSync, writeFileSync} from 'fs';
+import {existsSync, mkdirSync, readFileSync, writeFileSync} from 'fs';
 import {type DocumentNode} from 'graphql';
 import {print} from 'graphql/language/printer';
 import {validate} from 'graphql/validation';


### PR DESCRIPTION
## Summary:
On mobile we were using our graphql-flow setup to collect all graphql operations, so adding this option is necessary to fully replace it.

Issue: none

## Test plan:
In the mobile repo, run `yarn test queries`, copy the `.graphql-safelist/extracted_graphql_queries.json` file somewhere, then run this tool, and compare the two dump files. They should be identical!