### PR TITLE
Add support for generatedDir being an absolute path.

### DIFF
--- a/.changeset/fuzzy-ties-jump.md
+++ b/.changeset/fuzzy-ties-jump.md
@@ -1,0 +1,5 @@
+---
+'@khanacademy/graphql-flow': patch
+---
+
+Allow generatedDir to be an absolute path

--- a/Readme.md
+++ b/Readme.md
@@ -51,7 +51,7 @@ type Options = {
     // * if `generatedDirectory` is "__generated__", the output will
     //   be in /foo/bar/baz/__generated__/index.js and sibling files
     // * if `generatedDirectory` is "/tmp/__generated__", the output
-    //   will be in /tmp/__generated__/bar/baz/idnex.js and sibling
+    //   will be in /tmp/__generated__/bar/baz/index.js and sibling
     //   files.
     generatedDirectory: string = '__generated__',
 

--- a/Readme.md
+++ b/Readme.md
@@ -42,7 +42,17 @@ type Options = {
     readOnlyArray: boolean = true,
     scalars: {[key: string]: 'string' | 'boolean' | 'number'}
 
-    // Specify the name of the generated types directory
+    // Specify the name of the generated types directory.  If this
+    // is a relative path, then this is used to suffix the output
+    // directory; if it's an absolute path it's used to prefix the
+    // output directory.  For instance, if a gql directive is
+    // found in /foo/bar/baz/query.js and you run the cli (or
+    // jest) from directory /foo, then:
+    // * if `generatedDirectory` is "__generated__", the output will
+    //   be in /foo/bar/baz/__generated__/index.js and sibling files
+    // * if `generatedDirectory` is "/tmp/__generated__", the output
+    //   will be in /tmp/__generated__/bar/baz/idnex.js and sibling
+    //   files.
     generatedDirectory: string = '__generated__',
 
     // The default generated type contains both the types of the response

--- a/src/cli/config.js
+++ b/src/cli/config.js
@@ -78,10 +78,9 @@ export const loadConfigFile = (configFile: string): CliConfig => {
     return {
         options: data.options ?? {},
         excludes: data.excludes?.map((string) => new RegExp(string)) ?? [],
-        schemaFilePath: path.join(
-            path.dirname(configFile),
-            data.schemaFilePath,
-        ),
+        schemaFilePath: path.isAbsolute(data.schemaFilePath)
+            ? data.schemaFilePath
+            : path.join(path.dirname(configFile), data.schemaFilePath),
         dumpOperations: data.dumpOperations,
     };
 };

--- a/src/generateTypeFiles.js
+++ b/src/generateTypeFiles.js
@@ -113,7 +113,7 @@ export const generateTypeFiles = (
               // for more reasonable filenames.  We convert leading ..'s
               // to `__` so this doesn't escape the output directory.
               path
-                .relative(process.cwd(), path.dirname(fileName))
+                  .relative(process.cwd(), path.dirname(fileName))
                   .replace(/\.\.\//g, '__/'),
           )
         : path.join(

--- a/src/generateTypeFiles.js
+++ b/src/generateTypeFiles.js
@@ -106,10 +106,13 @@ export const generateTypeFiles = (
     document: DocumentNode,
     options: Options,
 ) => {
-    const generatedDir = path.join(
-        path.dirname(fileName),
-        options.generatedDirectory ?? '__generated__',
-    );
+    const generatedDir =
+          path.isAbsolute(options.generatedDirectory ?? "")
+          ? path.join(options.generatedDirectory, path.dirname(fileName))
+          : path.join(
+              path.dirname(fileName),
+              options.generatedDirectory ?? '__generated__',
+          );
     const indexFile = path.join(generatedDir, 'index.js');
 
     if (!fs.existsSync(generatedDir)) {

--- a/src/generateTypeFiles.js
+++ b/src/generateTypeFiles.js
@@ -100,26 +100,30 @@ export const generateTypeFileContents = (
     return {files, indexContents};
 };
 
+const getGeneratedDir = (fileName: string, options: Options) => {
+    const generatedDirectory = options.generatedDirectory ?? '__generated__';
+    if (path.isAbsolute(generatedDirectory)) {
+        // fileName is absolute here, so we make it relative to cwd
+        // for more reasonable filenames.  We convert leading ..'s
+        // to `__` so this doesn't escape the output directory.
+        return path.join(
+            generatedDirectory,
+            path
+                .relative(process.cwd(), path.dirname(fileName))
+                .replace(/\.\.\//g, '__/'),
+        );
+    } else {
+        return path.join(path.dirname(fileName), generatedDirectory);
+    }
+};
+
 export const generateTypeFiles = (
     fileName: string,
     schema: Schema,
     document: DocumentNode,
     options: Options,
 ) => {
-    const generatedDir = path.isAbsolute(options.generatedDirectory ?? '')
-        ? path.join(
-              options.generatedDirectory ?? '', // The '' is to quiet flow
-              // fileName is absolute here, so we make it relative to cwd
-              // for more reasonable filenames.  We convert leading ..'s
-              // to `__` so this doesn't escape the output directory.
-              path
-                  .relative(process.cwd(), path.dirname(fileName))
-                  .replace(/\.\.\//g, '__/'),
-          )
-        : path.join(
-              path.dirname(fileName),
-              options.generatedDirectory ?? '__generated__',
-          );
+    const generatedDir = getGeneratedDir(fileName, options);
     const indexFile = path.join(generatedDir, 'index.js');
 
     if (!fs.existsSync(generatedDir)) {

--- a/src/generateTypeFiles.js
+++ b/src/generateTypeFiles.js
@@ -106,10 +106,17 @@ export const generateTypeFiles = (
     document: DocumentNode,
     options: Options,
 ) => {
-    const generatedDir =
-          path.isAbsolute(options.generatedDirectory ?? "")
-          ? path.join(options.generatedDirectory, path.dirname(fileName))
-          : path.join(
+    const generatedDir = path.isAbsolute(options.generatedDirectory ?? '')
+        ? path.join(
+              options.generatedDirectory ?? '', // The '' is to quiet flow
+              // fileName is absolute here, so we make it relative to cwd
+              // for more reasonable filenames.  We convert leading ..'s
+              // to `__` so this doesn't escape the output directory.
+              path
+                .relative(process.cwd(), path.dirname(fileName))
+                  .replace(/\.\.\//g, '__/'),
+          )
+        : path.join(
               path.dirname(fileName),
               options.generatedDirectory ?? '__generated__',
           );


### PR DESCRIPTION
## Summary:
In this (currently) undocumented mode, the output goes into
```
    generatedDir/dirname/opname.js
```
rather than
```
    dirname/generatedDir/opname.js
```

This is useful if you want to keep all the output in a single tree
separate from the rest of your codebase.  I want to do this for some
validation tests, but I could see people wanting to do it if they have
read-only workspaces or something like that.

Unfortunately, `dirname` is always an absolute path currently, which
makes the output-directory structure depends on your own local
filesystem in ways that is not ideal.  I resolve this by making dirname relative to the current working directory, taking some care that the resulting output file can't escape the output generated-directroy.

Issue: https://khanacademy.atlassian.net/browse/INFRA-7885

## Test plan:
I created a config file that looked like this:
```
{
	"schemaFilePath": ...,
	"options": {
		"generatedDirectory": "/tmp/gqlflow",
	}
}
```
and then ran
```
node ~/khan/graphql-flow/dist/cli/run.js /tmp/gqlflow/config.json
```
and saw output files like:
```
/tmp/gqlflow/services/static/javascript/promos-package/getPromoForUser.js
```
which is just what I was hoping to see.