### PR TITLE
Back out the subconfigs logic (will be replacing it in upcoming diff) & simplify some types

### DIFF
--- a/src/cli/__test__/config.test.js
+++ b/src/cli/__test__/config.test.js
@@ -1,101 +1,6 @@
 // @flow
-import {loadDirConfigFiles, validateOrThrow} from '../config';
-import jsonSchema from '../schema.json';
-
-import fs from 'fs';
-jest.mock('fs');
-
-const filesResponse = `javascript/discussion-package/components/graphql-flow.config.json
-javascript/discussion-package/graphql-flow.config.json
-`;
-const rootConfigPath = './dev/graphql-flow/config.json';
-const mockRootConfig = {
-    path: rootConfigPath,
-    config: {
-        options: {
-            splitTypes: true,
-            readOnlyArray: false,
-        },
-        excludes: [/this one/, /that one/],
-        schemaFilePath: 'this/is/a/path.graphql',
-        dumpOperations: '',
-    },
-};
-const firstFileFixture = {
-    extends: 'javascript/discussion-package/graphql-flow.config.json',
-    options: {
-        splitTypes: false,
-    },
-    excludes: ['that one'],
-};
-const secondFileFixture = {
-    extends: rootConfigPath,
-    options: {
-        readOnlyArray: true,
-    },
-    excludes: ['another one'],
-};
-
-describe('loading subconfigs', () => {
-    it('should properly extend', () => {
-        // eslint-disable-next-line flowtype-errors/uncovered
-        fs.readFileSync
-            // $FlowIgnore
-            .mockReturnValueOnce(JSON.stringify(firstFileFixture))
-            .mockReturnValueOnce(JSON.stringify(secondFileFixture));
-
-        const dirConfigMap = loadDirConfigFiles(filesResponse, mockRootConfig);
-
-        const paths = Object.keys(dirConfigMap);
-        const subConfig = dirConfigMap[paths[0]];
-        const deeperConfig = dirConfigMap[paths[1]];
-
-        expect(paths).toHaveLength(2);
-
-        expect(subConfig.options.splitTypes).toBe(true);
-        expect(subConfig.options.readOnlyArray).toBe(true);
-        expect(subConfig.excludes.length).toBe(3);
-
-        expect(deeperConfig.options.splitTypes).toBe(false);
-        expect(subConfig.options.readOnlyArray).toBe(true);
-        expect(subConfig.excludes.length).toBe(3);
-    });
-    it('should properly overwrite', () => {
-        // eslint-disable-next-line flowtype-errors/uncovered
-        fs.readFileSync
-            // $FlowIgnore
-            .mockReturnValueOnce(
-                JSON.stringify({
-                    options: {},
-                    excludes: ['some other one'],
-                }),
-            )
-            .mockReturnValueOnce(
-                JSON.stringify({
-                    options: {
-                        splitTypes: false,
-                    },
-                    excludes: ['a completely different one one'],
-                }),
-            );
-
-        const dirConfigMap = loadDirConfigFiles(filesResponse, mockRootConfig);
-
-        const paths = Object.keys(dirConfigMap);
-        const subConfig = dirConfigMap[paths[0]];
-        const deeperConfig = dirConfigMap[paths[1]];
-
-        expect(paths).toHaveLength(2);
-
-        expect(subConfig.options.splitTypes).toBe(undefined);
-        expect(subConfig.options.readOnlyArray).toBe(undefined);
-        expect(subConfig.excludes.length).toBe(1);
-
-        expect(deeperConfig.options.splitTypes).toBe(false);
-        expect(subConfig.options.readOnlyArray).toBe(undefined);
-        expect(subConfig.excludes.length).toBe(1);
-    });
-});
+import {validateOrThrow} from '../config';
+import configSchema from '../schema.json'; // eslint-disable-line flowtype-errors/uncovered
 
 describe('jsonschema validation', () => {
     it('should accept valid schema', () => {
@@ -122,21 +27,15 @@ describe('jsonschema validation', () => {
                     exportAllObjectTypes: true,
                 },
             },
-            jsonSchema,
+            configSchema, // eslint-disable-line flowtype-errors/uncovered
         );
     });
 
     it('should reject invalid schema', () => {
         expect(() =>
             validateOrThrow(
-                {
-                    schemaFilePath: 10,
-                    options: {
-                        extraOption: 'hello',
-                    },
-                },
-
-                jsonSchema,
+                {schemaFilePath: 10, options: {extraOption: 'hello'}},
+                configSchema, // eslint-disable-line flowtype-errors/uncovered
             ),
         ).toThrowErrorMatchingInlineSnapshot(
             `"instance.schemaFilePath is not of a type(s) string"`,

--- a/src/cli/config.js
+++ b/src/cli/config.js
@@ -4,7 +4,7 @@ import type {Schema} from '../types';
 import type {GraphQLSchema} from 'graphql/type/schema';
 
 import {schemaFromIntrospectionData} from '../schemaFromIntrospectionData';
-import configSchema from './schema.json';
+import configSchema from './schema.json'; // eslint-disable-line flowtype-errors/uncovered
 
 import fs from 'fs';
 import {
@@ -14,21 +14,13 @@ import {
     graphqlSync,
     type IntrospectionQuery,
 } from 'graphql';
-import path from 'path';
-import {validate} from 'jsonschema';
-
-export type CliConfig = {
-    excludes: Array<RegExp>,
-    schemaFilePath: string,
-    dumpOperations?: string,
-    options: ExternalOptions,
-};
+import {validate} from 'jsonschema'; // eslint-disable-line flowtype-errors/uncovered
 
 /**
  * This is the json-compatible form of the config
  * object.
  */
-type JSONConfig = {
+type Config = {
     excludes?: Array<string>,
     schemaFilePath: string,
     options?: ExternalOptions,
@@ -36,117 +28,22 @@ type JSONConfig = {
 };
 
 export const validateOrThrow = (value: mixed, jsonSchema: mixed) => {
+    /* eslint-disable flowtype-errors/uncovered */
     const result = validate(value, jsonSchema);
     if (!result.valid) {
         throw new Error(
             result.errors.map((error) => error.toString()).join('\n'),
         );
     }
+    /* eslint-enable flowtype-errors/uncovered */
 };
 
-export const loadConfigFile = (configFile: string): CliConfig => {
+export const loadConfigFile = (configFile: string): Config => {
     // eslint-disable-next-line flowtype-errors/uncovered
-    const data: JSONConfig = JSON.parse(fs.readFileSync(configFile, 'utf8'));
+    const data: Config = JSON.parse(fs.readFileSync(configFile, 'utf8'));
+    // eslint-disable-next-line flowtype-errors/uncovered
     validateOrThrow(data, configSchema);
-    return {
-        options: data.options ?? {},
-        excludes: data.excludes?.map((string) => new RegExp(string)) ?? [],
-        schemaFilePath: path.isAbsolute(data.schemaFilePath)
-            ? data.schemaFilePath
-            : path.join(path.dirname(configFile), data.schemaFilePath),
-        dumpOperations: data.dumpOperations,
-    };
-};
-
-/**
- * Subdirectory config to extend or overwrite higher-level config.
- * @param {string} extends - Path from root; optional field for a config file in a subdirectory. If left blank, config file will overwrite root for directory.
- */
-type JSONSubConfig = {
-    excludes?: Array<string>,
-    options?: ExternalOptions,
-    extends?: string,
-};
-
-type SubConfig = {
-    excludes: Array<RegExp>,
-    options: ExternalOptions,
-    extends?: string,
-};
-
-const subSchema = {...configSchema, required: []};
-subSchema.properties = {...configSchema.properties, extends: {type: 'string'}};
-delete subSchema.properties.schemaFilePath;
-
-export const loadSubConfigFile = (configFile: string): SubConfig => {
-    const jsonData = fs.readFileSync(configFile, 'utf8');
-    // eslint-disable-next-line flowtype-errors/uncovered
-    const data: JSONSubConfig = JSON.parse(jsonData);
-    const toplevelKeys = ['excludes', 'options', 'extends'];
-    Object.keys(data).forEach((k) => {
-        if (!toplevelKeys.includes(k)) {
-            throw new Error(
-                `Invalid attribute in non-root config file ${configFile}: ${k}. Allowed attributes: ${toplevelKeys.join(
-                    ', ',
-                )}`,
-            );
-        }
-    });
-    validateOrThrow(data, subSchema);
-    return {
-        excludes: data.excludes?.map((string) => new RegExp(string)) ?? [],
-        options: data.options ?? {},
-        extends: data.extends ?? '',
-    };
-};
-
-export const loadDirConfigFiles = (
-    filesResponse: string,
-    rootConfig: {path: string, config: CliConfig},
-): {[dir: string]: SubConfig} => {
-    const dirConfigMap: {[key: string]: SubConfig} = {};
-
-    // TODO: circular extends will cause infinite loop... consider instrumenting code to monitor for loops in the future?
-    const loadExtendedConfig = (configPath: string): SubConfig => {
-        let dirConfig = loadSubConfigFile(configPath);
-        if (dirConfig.extends) {
-            const isRootConfig = dirConfig.extends === rootConfig.path;
-            const {options, excludes} = isRootConfig
-                ? rootConfig.config
-                : addConfig(dirConfig.extends);
-            dirConfig = extendConfig({options, excludes}, dirConfig);
-        }
-        return dirConfig;
-    };
-    const addConfig = (configPath) => {
-        const {dir} = path.parse(configPath);
-        if (dirConfigMap[dir]) {
-            return dirConfigMap[dir];
-        }
-        dirConfigMap[dir] = loadExtendedConfig(configPath);
-        return dirConfigMap[dir];
-    };
-    const extendConfig = (
-        toExtend: SubConfig,
-        current: SubConfig,
-    ): SubConfig => ({
-        // $FlowFixMe[exponential-spread]
-        options: {...toExtend.options, ...current.options},
-        excludes: Array.from(
-            new Set([...toExtend.excludes, ...current.excludes]),
-        ),
-    });
-
-    filesResponse
-        .trim()
-        .split('\n')
-        .forEach((configPath) => {
-            const {dir} = path.parse(configPath);
-            if (dir && !dirConfigMap[dir]) {
-                dirConfigMap[dir] = loadExtendedConfig(configPath);
-            }
-        });
-    return dirConfigMap;
+    return data;
 };
 
 /**


### PR DESCRIPTION
## Summary:
So https://github.com/Khan/graphql-flow/pull/48 is pretty large, so I'm splitting it up into chunks. This is the first one.
In https://khanacademy.slack.com/archives/C02NMB1R5/p1654111779630689 we decided that we'd switch to having per-directory overrides be handled all in one config file instead of allowing multiple config files, so I'm backing out the multi-file stuff first.

Issue: XXX-XXXX

## Test plan:
See the checks