### PR TITLE
Fix processing to handle typescript imports with no extension

### DIFF
--- a/.changeset/bright-pandas-dance.md
+++ b/.changeset/bright-pandas-dance.md
@@ -1,0 +1,5 @@
+---
+'@khanacademy/graphql-flow': patch
+---
+
+Fix processing of typescript imports that don't use an extension

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,8 @@
 [ignore]
 ; The 'resolve' package bundles test files that it really shouldn't
 .*/resolve/test/resolver/malformed_package_json/
+<PROJECT_ROOT>/dist/
+
 [include]
 
 [libs]

--- a/src/cli/config.js
+++ b/src/cli/config.js
@@ -28,10 +28,9 @@ export const validateOrThrow = (value: mixed, jsonSchema: mixed) => {
 };
 
 export const loadConfigFile = (configFile: string): Config => {
-    // $FlowIgnore // eslint-disable-next-line flowtype-errors/uncovered
-    const data: Config = require(configFile);
-    // eslint-disable-next-line flowtype-errors/uncovered
-    validateOrThrow(data, configSchema);
+    // $FlowIgnore
+    const data: Config = require(configFile); // eslint-disable-line flowtype-errors/uncovered
+    validateOrThrow(data, configSchema); // eslint-disable-line flowtype-errors/uncovered
     return data;
 };
 

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 // @flow
 /* eslint-disable no-console */
+import type {Schema} from '../types';
+import type {GraphQLSchema} from 'graphql/type/schema';
+
 import {generateTypeFiles, processPragmas} from '../generateTypeFiles';
 import {processFiles} from '../parser/parse';
 import {resolveDocuments} from '../parser/resolve';
@@ -15,7 +18,6 @@ import {print} from 'graphql/language/printer';
 import {validate} from 'graphql/validation';
 import path from 'path';
 import {dirname} from 'path';
-import type {GenerateConfig} from '../types';
 
 /**
  * This CLI tool executes the following steps:
@@ -127,7 +129,7 @@ console.log(Object.keys(resolved).length, 'resolved queries');
 
 /** Step (4) */
 
-const schemaCache = {};
+const schemaCache: {[key: string]: [GraphQLSchema, Schema]} = {};
 const getCachedSchemas = (schemaFilePath: string) => {
     if (!schemaCache[schemaFilePath]) {
         schemaCache[schemaFilePath] = getSchemas(

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -81,7 +81,16 @@ const files = processFiles(inputFiles, (f) => {
         return readFileSync(f, 'utf8');
     }
     if (existsSync(f + '.js')) {
-        return readFileSync(f + '.js', 'utf8');
+        return {text: readFileSync(f + '.js', 'utf8'), resolvedPath: f + '.js'};
+    }
+    if (existsSync(f + '.ts')) {
+        return {text: readFileSync(f + '.ts', 'utf8'), resolvedPath: f + '.ts'};
+    }
+    if (existsSync(f + '.tsx')) {
+        return {
+            text: readFileSync(f + '.tsx', 'utf8'),
+            resolvedPath: f + '.tsx',
+        };
     }
     throw new Error(`Unable to find ${f}`);
 });

--- a/src/generateTypeFiles.js
+++ b/src/generateTypeFiles.js
@@ -4,6 +4,7 @@ import type {GenerateConfig, CrawlConfig, Schema} from './types';
 import fs from 'fs';
 import path from 'path';
 import {documentToFlowTypes} from '.';
+// eslint-disable-next-line flowtype-errors/uncovered
 import {convert} from '@khanacademy/flow-to-ts/dist/convert.bundle';
 
 export const indexPrelude = (regenerateCommand?: string): string => `// @flow
@@ -150,6 +151,7 @@ export const generateTypeFiles = (
     Object.keys(files).forEach((key) => {
         let fname = key;
         if (options.typeScript) {
+            // eslint-disable-next-line flowtype-errors/uncovered
             files[key] = convert(files[key]);
             fname = key.replace(/\.js$/, '.ts');
         }

--- a/src/parser/__test__/parse.test.js
+++ b/src/parser/__test__/parse.test.js
@@ -5,7 +5,9 @@ import {resolveDocuments} from '../resolve';
 
 import {print} from 'graphql/language/printer';
 
-const fixtureFiles: {[key: string]: string} = {
+const fixtureFiles: {
+    [key: string]: string | {text: string, resolvedPath: string},
+} = {
     '/firstFile.js': `
         // Note that you can import graphql-tag as
         // something other than gql.


### PR DESCRIPTION
## Summary:
We were assuming that any imports without an extension would be js/flow, not typescript, so I was getting syntax errors running it on the newly-converted mobile repo.

Issue: https://khanacademy.atlassian.net/browse/FEI-5146

## Test plan:
Now running it on `feature/ts` in the mobile repo works!