### PR TITLE
Fix empty `variables` object to appease typescript-eslint

### DIFF
--- a/src/generateTypeFiles.js
+++ b/src/generateTypeFiles.js
@@ -152,7 +152,10 @@ export const generateTypeFiles = (
         let fname = key;
         if (options.typeScript) {
             // eslint-disable-next-line flowtype-errors/uncovered
-            files[key] = convert(files[key]);
+            files[key] = convert(files[key]).replace(
+                `variables: {}`,
+                `variables: Record<never, never>`,
+            );
             fname = key.replace(/\.js$/, '.ts');
         }
         fs.writeFileSync(fname, files[key]);


### PR DESCRIPTION
## Summary:
So, right now we're lazily using [flow-to-ts](https://github.com/Khan/flow-to-ts), which hasn't been updated in a while, and likely shouldn't be depended upon long-term.
The ~real ~better solution will be to just buckle down and produce typescript directly, instead of producing flow and then converting to typescript ... but that will be a battle for another day.

## Test plan:
Run on the mobile repo, see that `eslint` is happy