### PR TITLE
Add option to omit file extensions from import statements in index.js files

### DIFF
--- a/.changeset/fifty-pumas-count.md
+++ b/.changeset/fifty-pumas-count.md
@@ -1,0 +1,5 @@
+---
+'@khanacademy/graphql-flow': minor
+---
+
+Add --omitFileExtensions option

--- a/src/cli/schema.json
+++ b/src/cli/schema.json
@@ -57,6 +57,9 @@
                 },
                 "experimentalEnums": {
                     "type": "boolean"
+                },
+                "omitFileExtensions": {
+                    "type": "boolean"
                 }
             },
             "required": [

--- a/src/generateTypeFiles.js
+++ b/src/generateTypeFiles.js
@@ -29,23 +29,17 @@ export const generateTypeFileContents = (
 
     /// Write export for __generated__/index.js if it doesn't exist
     const addToIndex = (filePath, typeName) => {
-        if (options.typeScript) {
+        if (options.typeScript || options.omitFileExtensions) {
             // Typescript doesn't like file extensions
             filePath = filePath.replace(/\.js$/, '');
         }
         const newLine = `export type {${typeName}} from './${path.basename(
             filePath,
         )}';`;
-        if (indexContents.indexOf('./' + path.basename(filePath)) === -1) {
+        // We match the entire new line to avoid issues that can arise from
+        // prefix matches.
+        if (indexContents.indexOf(newLine) === -1) {
             indexContents += newLine + '\n';
-        } else {
-            const lines = indexContents.split('\n').map((line) => {
-                if (line.includes('./' + path.basename(filePath))) {
-                    return newLine;
-                }
-                return line;
-            });
-            indexContents = lines.join('\n');
         }
     };
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ const optionsToConfig = (
         readOnlyArray: options?.readOnlyArray ?? true,
         scalars: options?.scalars ?? {},
         typeScript: options?.typeScript ?? false,
+        omitFileExtensions: options?.omitFileExtensions ?? false,
     };
     const fragments = {};
     definitions.forEach((def) => {

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -9,8 +9,9 @@ import type {
 import {parse} from '@babel/parser'; // eslint-disable-line flowtype-errors/uncovered
 import traverse from '@babel/traverse'; // eslint-disable-line flowtype-errors/uncovered
 
-import fs from 'fs';
 import path from 'path';
+
+import {getPathWithExtension} from './utils';
 
 /**
  * This file is responsible for finding all gql`-annotated
@@ -75,29 +76,6 @@ export type FileResult = {|
 |};
 
 export type Files = {[path: string]: FileResult};
-
-export const getPathWithExtension = (pathWithoutExtension: string): string => {
-    if (
-        /\.(less|css|png|gif|jpg|jpeg|js|jsx|ts|tsx|mjs)$/.test(
-            pathWithoutExtension,
-        )
-    ) {
-        return pathWithoutExtension;
-    }
-    if (fs.existsSync(pathWithoutExtension + '.js')) {
-        return pathWithoutExtension + '.js';
-    }
-    if (fs.existsSync(pathWithoutExtension + '.jsx')) {
-        return pathWithoutExtension + '.jsx';
-    }
-    if (fs.existsSync(pathWithoutExtension + '.tsx')) {
-        return pathWithoutExtension + '.tsx';
-    }
-    if (fs.existsSync(pathWithoutExtension + '.ts')) {
-        return pathWithoutExtension + '.ts';
-    }
-    throw new Error("Can't find file at " + pathWithoutExtension);
-};
 
 /**
  * Finds all referenced imports that might possibly be relevant

--- a/src/parser/parse.js
+++ b/src/parser/parse.js
@@ -9,6 +9,7 @@ import type {
 import {parse} from '@babel/parser'; // eslint-disable-line flowtype-errors/uncovered
 import traverse from '@babel/traverse'; // eslint-disable-line flowtype-errors/uncovered
 
+import fs from 'fs';
 import path from 'path';
 
 /**
@@ -75,6 +76,29 @@ export type FileResult = {|
 
 export type Files = {[path: string]: FileResult};
 
+export const getPathWithExtension = (pathWithoutExtension: string): string => {
+    if (
+        /\.(less|css|png|gif|jpg|jpeg|js|jsx|ts|tsx|mjs)$/.test(
+            pathWithoutExtension,
+        )
+    ) {
+        return pathWithoutExtension;
+    }
+    if (fs.existsSync(pathWithoutExtension + '.js')) {
+        return pathWithoutExtension + '.js';
+    }
+    if (fs.existsSync(pathWithoutExtension + '.jsx')) {
+        return pathWithoutExtension + '.jsx';
+    }
+    if (fs.existsSync(pathWithoutExtension + '.tsx')) {
+        return pathWithoutExtension + '.tsx';
+    }
+    if (fs.existsSync(pathWithoutExtension + '.ts')) {
+        return pathWithoutExtension + '.ts';
+    }
+    throw new Error("Can't find file at " + pathWithoutExtension);
+};
+
 /**
  * Finds all referenced imports that might possibly be relevant
  * graphql fragments.
@@ -88,7 +112,8 @@ const listExternalReferences = (file: FileResult): Array<string> => {
     const add = (v: Document | Import, followImports: boolean) => {
         if (v.type === 'import') {
             if (followImports) {
-                paths[v.path] = true;
+                const absPath = getPathWithExtension(v.path);
+                paths[absPath] = true;
             }
         } else {
             v.source.expressions.forEach((expr) => add(expr, true));

--- a/src/parser/resolve.js
+++ b/src/parser/resolve.js
@@ -1,6 +1,6 @@
 // @flow
-import fs from 'fs';
 import gql from 'graphql-tag';
+import {getPathWithExtension} from './utils';
 import type {DocumentNode} from 'graphql/language/ast';
 import type {FileResult, Files, Import, Template, Document} from './parse';
 
@@ -29,29 +29,6 @@ export const resolveDocuments = (
         });
     });
     return {resolved, errors};
-};
-
-export const getPathWithExtension = (pathWithoutExtension: string): string => {
-    if (
-        /\.(less|css|png|gif|jpg|jpeg|js|jsx|ts|tsx|mjs)$/.test(
-            pathWithoutExtension,
-        )
-    ) {
-        return pathWithoutExtension;
-    }
-    if (fs.existsSync(pathWithoutExtension + '.js')) {
-        return pathWithoutExtension + '.js';
-    }
-    if (fs.existsSync(pathWithoutExtension + '.jsx')) {
-        return pathWithoutExtension + '.jsx';
-    }
-    if (fs.existsSync(pathWithoutExtension + '.tsx')) {
-        return pathWithoutExtension + '.tsx';
-    }
-    if (fs.existsSync(pathWithoutExtension + '.ts')) {
-        return pathWithoutExtension + '.ts';
-    }
-    throw new Error("Can't find file at " + pathWithoutExtension);
 };
 
 const resolveImport = (

--- a/src/parser/utils.js
+++ b/src/parser/utils.js
@@ -1,0 +1,25 @@
+// @flow
+import fs from 'fs';
+
+export const getPathWithExtension = (pathWithoutExtension: string): string => {
+    if (
+        /\.(less|css|png|gif|jpg|jpeg|js|jsx|ts|tsx|mjs)$/.test(
+            pathWithoutExtension,
+        )
+    ) {
+        return pathWithoutExtension;
+    }
+    if (fs.existsSync(pathWithoutExtension + '.js')) {
+        return pathWithoutExtension + '.js';
+    }
+    if (fs.existsSync(pathWithoutExtension + '.jsx')) {
+        return pathWithoutExtension + '.jsx';
+    }
+    if (fs.existsSync(pathWithoutExtension + '.tsx')) {
+        return pathWithoutExtension + '.tsx';
+    }
+    if (fs.existsSync(pathWithoutExtension + '.ts')) {
+        return pathWithoutExtension + '.ts';
+    }
+    throw new Error("Can't find file at " + pathWithoutExtension);
+};

--- a/src/types.js
+++ b/src/types.js
@@ -32,6 +32,7 @@ export type GenerateConfig = {|
     exportAllObjectTypes?: boolean,
     typeFileName?: string,
     experimentalEnums?: boolean,
+    omitFileExtensions?: boolean,
 |};
 
 export type CrawlConfig = {


### PR DESCRIPTION
## Summary:
We're removing file extensions from all import statements in services/static/ to make it easier to migrate to TS.  In order for this to work though we need to make sure that 'graphql-flow' can generate files whose import statements also have no file extensions.

This PR also fixes an issue in 'generateTypeFileContents' where it was clobbering and then re-adding imports.

Issue: None

## Test plan:
- yarn test
- yarn link
- cd ../webapp
- yarn link @khanacademy/graphql-flow
- update graphql-flow/config.js to use the new `omitFileExtensions` option
- make gqlflow