### PR TITLE
Update 'graphql' to 16.3.x so that we can update 'vite' in webapp

### DIFF
--- a/.changeset/violet-avocados-suffer.md
+++ b/.changeset/violet-avocados-suffer.md
@@ -1,0 +1,5 @@
+---
+'@khanacademy/graphql-flow': major
+---
+
+Update 'graphql' to 16.3.x (requires consumers to change their version of 'graphql')

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "@babel/types": "^7.17.0",
         "@khanacademy/wonder-stuff-core": "^1.5.1",
         "apollo-utilities": "^1.3.4",
-        "graphql": "14.5.8",
+        "graphql": "^16.3.0",
         "jsonschema": "^1.4.1",
         "prettier": "^2.5.1",
         "prettier-eslint": "^13.0.0"

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -39,13 +39,13 @@ export const getSchemas = (schemaFilePath: string): [GraphQLSchema, Schema] => {
     const raw = fs.readFileSync(schemaFilePath, 'utf8');
     if (schemaFilePath.endsWith('.graphql')) {
         const schemaForValidation = buildSchema(raw);
-        const queryResponse = graphqlSync(
-            schemaForValidation,
-            getIntrospectionQuery({descriptions: true}),
-        );
+        const queryResponse = graphqlSync({
+            schema: schemaForValidation,
+            source: getIntrospectionQuery({descriptions: true}),
+        });
         const schemaForTypeGeneration = schemaFromIntrospectionData(
             // eslint-disable-next-line flowtype-errors/uncovered
-            (queryResponse.data as IntrospectionQuery),
+            ((queryResponse.data as any) as IntrospectionQuery),
         );
         return [schemaForValidation, schemaForTypeGeneration];
     } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3609,12 +3609,10 @@ graphql-tag@2.10.1:
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.1.tgz#10aa41f1cd8fae5373eaf11f1f67260a3cad5e02"
   integrity sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==
 
-graphql@14.5.8:
-  version "14.5.8"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.5.8.tgz#504f3d3114cb9a0a3f359bbbcf38d9e5bf6a6b3c"
-  integrity sha512-MMwmi0zlVLQKLdGiMfWkgQD7dY/TUKt4L+zgJ/aR0Howebod3aNgP5JkgvAULiR2HPVZaP2VEElqtdidHweLkg==
-  dependencies:
-    iterall "^1.2.2"
+graphql@^16.3.0:
+  version "16.8.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.8.0.tgz#374478b7f27b2dc6153c8f42c1b80157f79d79d4"
+  integrity sha512-0oKGaR+y3qcS5mCu1vb7KG+a89vjn06C7Ihq/dDl3jA+A8B3TKomvi3CiEcVLJQGalbu8F52LxkOym7U5sSfbg==
 
 hard-rejection@^2.1.0:
   version "2.1.0"
@@ -4078,11 +4076,6 @@ istanbul-reports@^3.1.3:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
-
-iterall@^1.2.2:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
-  integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
 
 jest-changed-files@^27.5.1:
   version "27.5.1"


### PR DESCRIPTION
## Summary:
We'd like to update 'vite' in webapp to 4.x, but the new version has issues with the graphql 14.x.  Updating graphql to 16.x fixes it, but it means we need to update graphql-flow to use the same version of graphql.

I bumped the version by a whole version since this change will break consumers unless they upgrade `graphql`.

Issue: None

## Test plan:
- yarn test