### PR TITLE
Search through untracked files for graphql-tag. Don't error out on files that can't be found.

### DIFF
--- a/.changeset/spicy-bugs-wave.md
+++ b/.changeset/spicy-bugs-wave.md
@@ -1,0 +1,5 @@
+---
+'@khanacademy/graphql-flow': patch
+---
+
+Search through untracked files for graphql-tag. Don't error out on files that can't be found.

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -32,8 +32,11 @@ import {dirname} from 'path';
 /** Step (1) */
 
 const findGraphqlTagReferences = (root: string): Array<string> => {
+    // NOTE(john): We want to include untracked files here so that we can
+    // generate types for them. This is useful for when we have a new file
+    // that we want to generate types for, but we haven't committed it yet.
     const response = execSync(
-        "git grep -I --word-regexp --name-only --fixed-strings 'graphql-tag' -- '*.js' '*.jsx' '*.ts' '*.tsx'",
+        "git grep -I --word-regexp --name-only --fixed-strings --untracked 'graphql-tag' -- '*.js' '*.jsx' '*.ts' '*.tsx'",
         {
             encoding: 'utf8',
             cwd: root,

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -105,7 +105,9 @@ const listExternalReferences = (file: FileResult): Array<string> => {
         if (v.type === 'import') {
             if (followImports) {
                 const absPath = getPathWithExtension(v.path);
-                paths[absPath] = true;
+                if (absPath) {
+                    paths[absPath] = true;
+                }
             }
         } else {
             v.source.expressions.forEach((expr) => add(expr, true));

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -21,7 +21,8 @@ export const getPathWithExtension = (pathWithoutExtension: string): string => {
         return pathWithoutExtension + '.ts';
     }
     // NOTE(john): This is a bit of a hack, but it's necessary for when we
-    // have a file that doesn't have an extension. This will happen when we
-    // delete all of the type files before re-running graphql-flow again.
+    // have a file that doesn't exist. This will happen when we delete all of
+    // the type files before re-running graphql-flow again. We want to ensure
+    // that we don't error out in this case.
     return "";
 };

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -20,5 +20,8 @@ export const getPathWithExtension = (pathWithoutExtension: string): string => {
     if (fs.existsSync(pathWithoutExtension + '.ts')) {
         return pathWithoutExtension + '.ts';
     }
-    throw new Error("Can't find file at " + pathWithoutExtension);
+    // NOTE(john): This is a bit of a hack, but it's necessary for when we
+    // have a file that doesn't have an extension. This will happen when we
+    // delete all of the type files before re-running graphql-flow again.
+    return "";
 };


### PR DESCRIPTION
## Summary:
This fixes two bugs:

1) Creating types wouldn't work if the files hadn't yet been checked in to Git. This fixes that by now searching through untracked files, as well.
2) The script couldn't run if the graphql type files didn't exist. This fixes that by gracefully handling paths that don't exist.

Issue: FEI-5065

## Test plan:
I built it and ran it in webapp and it worked as expected.