### PR TITLE
[FEI-6084] Fix handling of input objects with required attributes that have default values

### DIFF
--- a/.changeset/quick-lies-bathe.md
+++ b/.changeset/quick-lies-bathe.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/graphql-flow": patch
+---
+
+Fix handling of input objects with required attributes that have a default value

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
     "bin": {
         "graphql-flow": "./dist/cli/run.js"
     },
+    "jest": {
+        "testPathIgnorePatterns": ["dist"]
+    },
     "scripts": {
         "test": "jest",
         "publish:ci": "yarn run build && changeset publish",

--- a/src/__test__/example-schema.graphql
+++ b/src/__test__/example-schema.graphql
@@ -60,6 +60,7 @@ input CharacterInput {
   friends: [ID!]
   appearsIn: [Episode!]
   candies: PositiveNumber!
+  friendly: Boolean! = true
 }
 
 type Mutation {

--- a/src/__test__/graphql-flow.test.ts
+++ b/src/__test__/graphql-flow.test.ts
@@ -621,6 +621,7 @@ describe("graphql-flow generation", () => {
                     - JEDI*/
                     "NEW_HOPE" | "EMPIRE" | "JEDI"> | null | undefined;
                     candies: number;
+                    friendly?: boolean;
                   };
                 },
                     response: {

--- a/src/__test__/graphql-flow.test.ts
+++ b/src/__test__/graphql-flow.test.ts
@@ -621,7 +621,7 @@ describe("graphql-flow generation", () => {
                     - JEDI*/
                     "NEW_HOPE" | "EMPIRE" | "JEDI"> | null | undefined;
                     candies: number;
-                    friendly?: boolean;
+                    friendly?: boolean | null | undefined;
                   };
                 },
                     response: {

--- a/src/generateVariablesType.ts
+++ b/src/generateVariablesType.ts
@@ -31,7 +31,7 @@ export const inputObjectToFlow = (
                     vbl.description,
                     maybeOptionalObjectTypeProperty(
                         vbl.name,
-                        inputRefToFlow(ctx, vbl.type),
+                        inputRefToFlow(ctx, vbl.type, vbl.defaultValue != null),
                     ),
                 ),
             ),
@@ -58,9 +58,11 @@ export const maybeOptionalObjectTypeProperty = (
 export const inputRefToFlow = (
     ctx: Context,
     inputRef: IntrospectionInputTypeRef,
+    hasDefaultValue = false,
 ): babelTypes.TSType => {
     if (inputRef.kind === "NON_NULL") {
-        return _inputRefToFlow(ctx, inputRef.ofType);
+        const result = _inputRefToFlow(ctx, inputRef.ofType);
+        return hasDefaultValue ? nullableType(result) : result;
     }
     const result = _inputRefToFlow(ctx, inputRef);
     return transferLeadingComments(result, nullableType(result));


### PR DESCRIPTION
## Summary:
Previously they were mistakenly reported as non-nullable.

Issue: FEI-6084

## Test plan:
See updated snapshot; `friendly` is required with a default value, and the generated type has it as nullable.