### PR TITLE
Export `getIntrospectionQuery()` wrapper that uses the options we want to use

### DIFF
--- a/.changeset/hip-dodos-trade.md
+++ b/.changeset/hip-dodos-trade.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/graphql-flow": minor
+---
+
+Export the introspection options we use

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Run TypeScript
       if: steps.ts-files.outputs.filtered != '[]'
-      run: yarn tsc
+      run: yarn typecheck
 
     - id: eslint-reset
       uses: Khan/actions@filter-files-v1

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     },
     "scripts": {
         "test": "jest",
+        "typecheck": "tsc --noEmit",
         "publish:ci": "yarn run build && changeset publish",
         "build": "babel src --extensions '.ts, .tsx' --out-dir dist --ignore 'src/**/*.spec.ts','src/**/*.test.ts' && chmod 755 dist/cli/run.js"
     },

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -8,9 +8,7 @@ import fs from "fs";
 import {
     buildClientSchema,
     buildSchema,
-    getIntrospectionQuery,
     graphqlSync,
-    type IntrospectionOptions,
     type IntrospectionQuery,
 } from "graphql";
 import {validate} from "jsonschema";
@@ -19,10 +17,7 @@ import type {Config, GenerateConfig} from "../types";
 import {execSync} from "child_process";
 import path from "path";
 
-export const INTROSPECTION_OPTIONS: IntrospectionOptions = {
-    descriptions: true,
-    inputValueDeprecation: true,
-};
+import {getIntrospectionQuery} from "./get-introspection-query";
 
 export const validateOrThrow = (value: unknown, jsonSchema: unknown) => {
     const result = validate(value, jsonSchema);
@@ -97,7 +92,7 @@ export const getSchemas = (schemaFilePath: string): [GraphQLSchema, Schema] => {
         const schemaForValidation = buildSchema(raw);
         const queryResponse = graphqlSync({
             schema: schemaForValidation,
-            source: getIntrospectionQuery(INTROSPECTION_OPTIONS),
+            source: getIntrospectionQuery(),
         });
         const schemaForTypeGeneration = schemaFromIntrospectionData(
             queryResponse.data as any as IntrospectionQuery,

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -10,13 +10,19 @@ import {
     buildSchema,
     getIntrospectionQuery,
     graphqlSync,
-    IntrospectionQuery,
+    type IntrospectionOptions,
+    type IntrospectionQuery,
 } from "graphql";
 import {validate} from "jsonschema";
 import processArgs from "minimist";
 import type {Config, GenerateConfig} from "../types";
 import {execSync} from "child_process";
 import path from "path";
+
+export const INTROSPECTION_OPTIONS: IntrospectionOptions = {
+    descriptions: true,
+    inputValueDeprecation: true,
+};
 
 export const validateOrThrow = (value: unknown, jsonSchema: unknown) => {
     const result = validate(value, jsonSchema);
@@ -91,10 +97,7 @@ export const getSchemas = (schemaFilePath: string): [GraphQLSchema, Schema] => {
         const schemaForValidation = buildSchema(raw);
         const queryResponse = graphqlSync({
             schema: schemaForValidation,
-            source: getIntrospectionQuery({
-                descriptions: true,
-                inputValueDeprecation: true,
-            }),
+            source: getIntrospectionQuery(INTROSPECTION_OPTIONS),
         });
         const schemaForTypeGeneration = schemaFromIntrospectionData(
             queryResponse.data as any as IntrospectionQuery,

--- a/src/cli/get-introspection-query.ts
+++ b/src/cli/get-introspection-query.ts
@@ -1,0 +1,13 @@
+import {
+    getIntrospectionQuery as getIntrospectionQueryWithOptions,
+    type IntrospectionOptions,
+} from "graphql";
+
+const INTROSPECTION_OPTIONS: IntrospectionOptions = {
+    descriptions: true,
+    inputValueDeprecation: true,
+};
+
+export const getIntrospectionQuery = () => {
+    return getIntrospectionQueryWithOptions(INTROSPECTION_OPTIONS);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import type {Context, Schema, GenerateConfig} from "./types";
 // NOTE(kevinb): This is exported so that tooling in other repos can use
 // the same options for their introspection query.  In particular, we use
 // this in Khan/frontend when downloading the introspection JSON from prod.
-export {INTROSPECTION_OPTIONS} from "./cli/config";
+export {getIntrospectionQuery} from "./cli/get-introspection-query";
 
 const optionsToConfig = (
     schema: Schema,

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,11 @@ import type {Node} from "@babel/types";
 
 import type {Context, Schema, GenerateConfig} from "./types";
 
+// NOTE(kevinb): This is exported so that tooling in other repos can use
+// the same options for their introspection query.  In particular, we use
+// this in Khan/frontend when downloading the introspection JSON from prod.
+export {INTROSPECTION_OPTIONS} from "./cli/config";
+
 const optionsToConfig = (
     schema: Schema,
     definitions: ReadonlyArray<DefinitionNode>,


### PR DESCRIPTION
## Summary:
graphql-flow uses these options when we pass it composed_schema.graphql, but we weren't using these options in Khan/frontend when downloading the introspection JSON from production.  This PR exports a wrapper around `getIntrospectionQuery` that uses the options we want to use.  Once this PR lands, Khan/frontend should be updated to use this wrapper instead of the original function from `"graphql"`.

Issue: FEI-7058

## Test plan:
- let CI run checks