### PR TITLE
Make 'crawl' optional

### DIFF
--- a/.changeset/stupid-apricots-accept.md
+++ b/.changeset/stupid-apricots-accept.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/graphql-flow": minor
+---
+
+Make 'crawl' optional in config

--- a/package.json
+++ b/package.json
@@ -51,5 +51,6 @@
         "graphql": "^16.9.0",
         "jsonschema": "^1.4.1",
         "minimist": "^1.2.8"
-    }
+    },
+    "packageManager": "pnpm@10.0.0+sha512.b8fef5494bd3fe4cbd4edabd0745df2ee5be3e4b0b8b08fa643aa3e4c6702ccc0f00d68fa8a8c9858a735a0032485a44990ed2810526c875e416f001b17df12b"
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,5 @@
         "graphql": "^16.9.0",
         "jsonschema": "^1.4.1",
         "minimist": "^1.2.8"
-    },
-    "packageManager": "pnpm@10.0.0+sha512.b8fef5494bd3fe4cbd4edabd0745df2ee5be3e4b0b8b08fa643aa3e4c6702ccc0f00d68fa8a8c9858a735a0032485a44990ed2810526c875e416f001b17df12b"
+    }
 }

--- a/schema.json
+++ b/schema.json
@@ -112,5 +112,5 @@
             }
         }
     },
-    "required": [ "crawl", "generate" ]
+    "required": [ "generate" ]
 }

--- a/src/cli/__test__/config.test.ts
+++ b/src/cli/__test__/config.test.ts
@@ -146,7 +146,6 @@ describe("jsonschema validation", () => {
         ).toThrowErrorMatchingInlineSnapshot(`
             "instance is not allowed to have the additional property \\"schemaFilePath\\"
             instance is not allowed to have the additional property \\"options\\"
-            instance requires property \\"crawl\\"
             instance requires property \\"generate\\""
         `);
     });

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -66,6 +66,7 @@ const findGraphqlTagReferences = (root: string): Array<string> => {
             cwd: root,
         },
     );
+    response; // ?
     return response
         .trim()
         .split("\n")
@@ -73,14 +74,18 @@ const findGraphqlTagReferences = (root: string): Array<string> => {
 };
 
 export const getInputFiles = (options: CliOptions, config: Config) => {
-    return options.cliFiles.length
-        ? options.cliFiles
-        : findGraphqlTagReferences(
-              makeAbsPath(
-                  config.crawl.root,
-                  path.dirname(options.configFilePath),
-              ),
-          );
+    if (options.cliFiles.length) {
+        return options.cliFiles;
+    }
+    if (config.crawl) {
+        return findGraphqlTagReferences(
+            makeAbsPath(
+                config.crawl.root,
+                path.dirname(options.configFilePath),
+            ),
+        );
+    }
+    throw new Error("Either crawl or cliFiles must be provided");
 };
 
 /**

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -138,16 +138,18 @@ Object.keys(resolved).forEach((filePathAndLine) => {
         printedOperations.push(printed);
     }
 
-    const pragmaResult = processPragmas(
-        generateConfig,
-        config.crawl,
-        rawSource,
-    );
-    if (!pragmaResult.generate) {
-        return;
-    }
-    if (pragmaResult.strict != null) {
-        generateConfig.strictNullability = pragmaResult.strict;
+    if (config.crawl) {
+        const pragmaResult = processPragmas(
+            generateConfig,
+            config.crawl,
+            rawSource,
+        );
+        if (!pragmaResult.generate) {
+            return;
+        }
+        if (pragmaResult.strict != null) {
+            generateConfig.strictNullability = pragmaResult.strict;
+        }
     }
 
     const [schemaForValidation, schemaForTypeGeneration] = getCachedSchemas(
@@ -200,7 +202,7 @@ if (validationFailures) {
     process.exit(1);
 }
 
-if (config.crawl.dumpOperations) {
+if (config.crawl?.dumpOperations) {
     const dumpOperations = config.crawl.dumpOperations;
     const parent = dirname(dumpOperations);
     mkdirSync(parent, {recursive: true});

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,7 @@ export type CrawlConfig = {
 };
 
 export type Config = {
-    crawl: CrawlConfig;
+    crawl?: CrawlConfig;
     generate: GenerateConfig | Array<GenerateConfig>;
     alias?: Array<{
         find: RegExp | string;


### PR DESCRIPTION
## Summary:

'getInputFiles' was implemented in such a way that if files were provided via the command line, the 'crawl' option would be ignored.  The types still required 'crawl' to be specified in this situation even though it wasn't used.  This PR allows 'crawl' to be omitted from the config.  graphql-flow will only error if neither 'crawl' or a list of files (via the command line) are provided.

## Test Plan:

- `yarn typecheck`
- `yarn test`