### PR TITLE
Overhaul import resolution, relying on tsconfig for import aliases, and rspack-resolver for package imports

### DIFF
--- a/.changeset/modern-items-itch.md
+++ b/.changeset/modern-items-itch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/graphql-flow": major
+---
+
+Overhaul import resolution, relying on tsconfig for import aliases, and rspack-resolver for package imports. This removes the `alias` config option, instead requiring that aliases be defined in a `tsconfig.json`.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "@types/minimist": "^1.2.5",
         "@types/prop-types": "^15.7.12",
         "@types/react": "^18.3.3",
+        "@types/resolve": "^1.20.6",
         "@typescript-eslint/eslint-plugin": "^7.17.0",
         "@typescript-eslint/parser": "^7.17.0",
         "babel-jest": "23.4.2",
@@ -65,7 +66,10 @@
         "apollo-utilities": "^1.3.4",
         "graphql": "^16.9.0",
         "jsonschema": "^1.4.1",
-        "minimist": "^1.2.8"
+        "minimist": "^1.2.8",
+        "resolve": "^1.22.8",
+        "rspack-resolver": "^1.3.0",
+        "tsconfig-paths": "^4.2.0"
     },
     "packageManager": "pnpm@10.22.0+sha512.bf049efe995b28f527fd2b41ae0474ce29186f7edcb3bf545087bd61fbbebb2bf75362d1307fda09c2d288e1e499787ac12d4fcb617a974718a6051f2eee741c"
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
         "@types/minimist": "^1.2.5",
         "@types/prop-types": "^15.7.12",
         "@types/react": "^18.3.3",
-        "@types/resolve": "^1.20.6",
         "@typescript-eslint/eslint-plugin": "^7.17.0",
         "@typescript-eslint/parser": "^7.17.0",
         "babel-jest": "23.4.2",
@@ -67,7 +66,6 @@
         "graphql": "^16.9.0",
         "jsonschema": "^1.4.1",
         "minimist": "^1.2.8",
-        "resolve": "^1.22.8",
         "rspack-resolver": "^1.3.0",
         "tsconfig-paths": "^4.2.0"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,15 @@ importers:
       minimist:
         specifier: ^1.2.8
         version: 1.2.8
+      resolve:
+        specifier: ^1.22.8
+        version: 1.22.11
+      rspack-resolver:
+        specifier: ^1.3.0
+        version: 1.3.0
+      tsconfig-paths:
+        specifier: ^4.2.0
+        version: 4.2.0
     devDependencies:
       '@babel/cli':
         specifier: ^7.17.6
@@ -81,6 +90,9 @@ importers:
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.3
+      '@types/resolve':
+        specifier: ^1.20.6
+        version: 1.20.6
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.17.0
         version: 7.17.0(@typescript-eslint/parser@7.17.0(eslint@8.57.0)(typescript@5.1.6))(eslint@8.57.0)(typescript@5.1.6)
@@ -138,24 +150,24 @@ packages:
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+  '@babel/code-frame@7.28.6':
+    resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/compat-data@7.26.8':
     resolution: {integrity: sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.29.0':
-    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+  '@babel/compat-data@7.28.6':
+    resolution: {integrity: sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.26.10':
     resolution: {integrity: sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.29.0':
-    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+  '@babel/core@7.28.6':
+    resolution: {integrity: sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/eslint-parser@7.17.0':
@@ -169,8 +181,8 @@ packages:
     resolution: {integrity: sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+  '@babel/generator@7.28.6':
+    resolution: {integrity: sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.25.9':
@@ -303,8 +315,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@7.29.0':
-    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+  '@babel/parser@7.28.6':
+    resolution: {integrity: sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -802,12 +814,16 @@ packages:
     resolution: {integrity: sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.29.0':
-    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+  '@babel/traverse@7.28.6':
+    resolution: {integrity: sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.27.0':
     resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.28.6':
+    resolution: {integrity: sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
@@ -1221,6 +1237,9 @@ packages:
   '@types/react@18.3.3':
     resolution: {integrity: sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==}
 
+  '@types/resolve@1.20.6':
+    resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
+
   '@types/semver@6.2.3':
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
 
@@ -1468,6 +1487,81 @@ packages:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
+    cpu: [x64]
+    os: [win32]
+
+  '@unrs/rspack-resolver-binding-darwin-arm64@1.3.0':
+    resolution: {integrity: sha512-EcjI0Hh2HiNOM0B9UuYH1PfLWgE6/SBQ4dKoHXWNloERfveha/n6aUZSBThtPGnJenmdfaJYXXZtqyNbWtJAFw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@unrs/rspack-resolver-binding-darwin-x64@1.3.0':
+    resolution: {integrity: sha512-3CgG+mhfudDfnaDqwEl0W1mcGTto5f5mqPyJSXcWDxrnNc7pr/p01khIgWOoOD1eCwVejmgpYvRKGBwJPwgHOQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@unrs/rspack-resolver-binding-freebsd-x64@1.3.0':
+    resolution: {integrity: sha512-ww8BwryDrpXlSajwSIEUXEv8oKDkw04L2ke3hxjaxWohuBV8pAQie9XBS4yQTyREuL2ypcqbARfoCXJJzVp7ig==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@unrs/rspack-resolver-binding-linux-arm-gnueabihf@1.3.0':
+    resolution: {integrity: sha512-WyhonI1mkuAlnG2iaMjk7uy4aWX+FWi2Au8qCCwj57wVHbAEfrN6xN2YhzbrsCC+ciumKhj5c01MqwsnYDNzWQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/rspack-resolver-binding-linux-arm-musleabihf@1.3.0':
+    resolution: {integrity: sha512-+uCP6hIAMVWHKQnLZHESJ1U1TFVGLR3FTeaS2A4zB0k8w+IbZlWwl9FiBUOwOiqhcCCyKiUEifgnYFNGpxi3pw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/rspack-resolver-binding-linux-arm64-gnu@1.3.0':
+    resolution: {integrity: sha512-p+s/Wp8rf75Qqs2EPw4HC0xVLLW+/60MlVAsB7TYLoeg1e1CU/QCis36FxpziLS0ZY2+wXdTnPUxr+5kkThzwQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@unrs/rspack-resolver-binding-linux-arm64-musl@1.3.0':
+    resolution: {integrity: sha512-cZEL9jmZ2kAN53MEk+fFCRJM8pRwOEboDn7sTLjZW+hL6a0/8JNfHP20n8+MBDrhyD34BSF4A6wPCj/LNhtOIQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@unrs/rspack-resolver-binding-linux-ppc64-gnu@1.3.0':
+    resolution: {integrity: sha512-IOeRhcMXTNlk2oApsOozYVcOHu4t1EKYKnTz4huzdPyKNPX0Y9C7X8/6rk4aR3Inb5s4oVMT9IVKdgNXLcpGAQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@unrs/rspack-resolver-binding-linux-s390x-gnu@1.3.0':
+    resolution: {integrity: sha512-op54XrlEbhgVRCxzF1pHFcLamdOmHDapwrqJ9xYRB7ZjwP/zQCKzz/uAsSaAlyQmbSi/PXV7lwfca4xkv860/Q==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@unrs/rspack-resolver-binding-linux-x64-gnu@1.3.0':
+    resolution: {integrity: sha512-orbQF7sN02N/b9QF8Xp1RBO5YkfI+AYo9VZw0H2Gh4JYWSuiDHjOPEeFPDIRyWmXbQJuiVNSB+e1pZOjPPKIyg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@unrs/rspack-resolver-binding-linux-x64-musl@1.3.0':
+    resolution: {integrity: sha512-kpjqjIAC9MfsjmlgmgeC8U9gZi6g/HTuCqpI7SBMjsa7/9MvBaQ6TJ7dtnsV/+DXvfJ2+L5teBBXG+XxfpvIFA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@unrs/rspack-resolver-binding-wasm32-wasi@1.3.0':
+    resolution: {integrity: sha512-JAg0hY3kGsCPk7Jgh16yMTBZ6VEnoNR1DFZxiozjKwH+zSCfuDuM5S15gr50ofbwVw9drobIP2TTHdKZ15MJZQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@unrs/rspack-resolver-binding-win32-arm64-msvc@1.3.0':
+    resolution: {integrity: sha512-h5N83i407ntS3ndDkhT/3vC3Dj8oP0BIwMtekETNJcxk7IuWccSXifzCEhdxxu/FOX4OICGIHdHrxf5fJuAjfw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@unrs/rspack-resolver-binding-win32-ia32-msvc@1.3.0':
+    resolution: {integrity: sha512-9QH7Gq3dRL8Q/D6PGS3Dwtjx9yw6kbCEu6iBkAUhFTDAuVUk2L0H/5NekRVA13AQaSc3OsEUKt60EOn/kq5Dug==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@unrs/rspack-resolver-binding-win32-x64-msvc@1.3.0':
+    resolution: {integrity: sha512-IYuXJCuwBOVV0H73l6auaZwtAPHjCPBJkxd4Co0yO6dSjDM5Na5OceaxhUmJLZ3z8kuEGhTYWIHH7PchGztnlg==}
     cpu: [x64]
     os: [win32]
 
@@ -1863,8 +1957,8 @@ packages:
   ci-info@3.3.0:
     resolution: {integrity: sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==}
 
-  ci-info@4.4.0:
-    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
+  ci-info@4.3.1:
+    resolution: {integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==}
     engines: {node: '>=8'}
 
   cjs-module-lexer@1.2.2:
@@ -2496,9 +2590,6 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  function-bind@1.1.1:
-    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
-
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -2646,10 +2737,6 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  has@1.0.3:
-    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
-    engines: {node: '>= 0.4.0'}
-
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -2766,9 +2853,6 @@ packages:
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
-
-  is-core-module@2.8.1:
-    resolution: {integrity: sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==}
 
   is-data-view@1.0.2:
     resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
@@ -3868,10 +3952,6 @@ packages:
     resolution: {integrity: sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==}
     engines: {node: '>=10'}
 
-  resolve@1.22.0:
-    resolution: {integrity: sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==}
-    hasBin: true
-
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
@@ -3889,6 +3969,10 @@ packages:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
+
+  rspack-resolver@1.3.0:
+    resolution: {integrity: sha512-az/PLDwa1xijNv4bAFBS8mtqqJC1Y3lVyFag4cuyIUOHq/ft5kSZlHbqYaLZLpsQtPWv4ZGDo5ycySKJzUvU/A==}
+    deprecated: Please migrate to the brand new `@rspack/resolver` or `unrs-resolver` instead
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -4237,6 +4321,10 @@ packages:
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
+  tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
+
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
@@ -4537,7 +4625,7 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/code-frame@7.29.0':
+  '@babel/code-frame@7.28.6':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
       js-tokens: 4.0.0
@@ -4545,7 +4633,7 @@ snapshots:
 
   '@babel/compat-data@7.26.8': {}
 
-  '@babel/compat-data@7.29.0': {}
+  '@babel/compat-data@7.28.6': {}
 
   '@babel/core@7.26.10':
     dependencies:
@@ -4567,16 +4655,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/core@7.29.0':
+  '@babel/core@7.28.6':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
+      '@babel/code-frame': 7.28.6
+      '@babel/generator': 7.28.6
       '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.6)
       '@babel/helpers': 7.28.6
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.28.6
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.28.6
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
@@ -4603,9 +4691,9 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.1.0
 
-  '@babel/generator@7.29.1':
+  '@babel/generator@7.28.6':
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.28.6
       '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -4625,7 +4713,7 @@ snapshots:
 
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
-      '@babel/compat-data': 7.29.0
+      '@babel/compat-data': 7.28.6
       '@babel/helper-validator-option': 7.27.1
       browserslist: 4.24.4
       lru-cache: 5.1.1
@@ -4658,7 +4746,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.26.5
       debug: 4.3.5
       lodash.debounce: 4.0.8
-      resolve: 1.22.0
+      resolve: 1.22.11
     transitivePeerDependencies:
       - supports-color
 
@@ -4680,7 +4768,7 @@ snapshots:
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.28.6
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -4694,12 +4782,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.28.6
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
@@ -4776,7 +4864,7 @@ snapshots:
     dependencies:
       '@babel/types': 7.27.0
 
-  '@babel/parser@7.29.0':
+  '@babel/parser@7.28.6':
     dependencies:
       '@babel/types': 7.29.0
 
@@ -4824,9 +4912,9 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.26.10)':
@@ -4834,9 +4922,9 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.26.10)':
@@ -4844,14 +4932,14 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-import-assertions@7.26.0(@babel/core@7.26.10)':
@@ -4864,9 +4952,9 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.26.10)':
@@ -4874,9 +4962,9 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.26.10)':
@@ -4884,9 +4972,9 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.26.10)':
@@ -4894,9 +4982,9 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.26.10)':
@@ -4904,9 +4992,9 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.26.10)':
@@ -4914,9 +5002,9 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.26.10)':
@@ -4924,9 +5012,9 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.26.10)':
@@ -4934,9 +5022,9 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.26.10)':
@@ -4944,9 +5032,9 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.26.10)':
@@ -4954,14 +5042,14 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.26.10)':
@@ -4969,9 +5057,9 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.26.10)':
@@ -4979,9 +5067,9 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.26.10)':
@@ -5404,7 +5492,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
-      '@babel/types': 7.27.0
+      '@babel/types': 7.28.6
       esutils: 2.0.3
 
   '@babel/preset-typescript@7.27.0(@babel/core@7.26.10)':
@@ -5430,8 +5518,8 @@ snapshots:
 
   '@babel/template@7.28.6':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.0
+      '@babel/code-frame': 7.28.6
+      '@babel/parser': 7.28.6
       '@babel/types': 7.29.0
 
   '@babel/traverse@7.27.0':
@@ -5446,12 +5534,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/traverse@7.29.0':
+  '@babel/traverse@7.28.6':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
+      '@babel/code-frame': 7.28.6
+      '@babel/generator': 7.28.6
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.28.6
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
       debug: 4.4.3
@@ -5462,6 +5550,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
+
+  '@babel/types@7.28.6':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.0':
     dependencies:
@@ -5869,7 +5962,7 @@ snapshots:
   '@jest/source-map@27.5.1':
     dependencies:
       callsites: 3.1.0
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.11
       source-map: 0.6.1
 
   '@jest/test-result@27.5.1':
@@ -5882,7 +5975,7 @@ snapshots:
   '@jest/test-sequencer@27.5.1':
     dependencies:
       '@jest/test-result': 27.5.1
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.11
       jest-haste-map: 27.5.1
       jest-runtime: 27.5.1
     transitivePeerDependencies:
@@ -5910,7 +6003,7 @@ snapshots:
 
   '@jest/transform@30.2.0':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.28.6
       '@jest/types': 30.2.0
       '@jridgewell/trace-mapping': 0.3.25
       babel-plugin-istanbul: 7.0.1
@@ -5968,8 +6061,8 @@ snapshots:
 
   '@jridgewell/remapping@2.3.5':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.8
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -6086,7 +6179,7 @@ snapshots:
 
   '@types/babel__core@7.1.18':
     dependencies:
-      '@babel/parser': 7.27.0
+      '@babel/parser': 7.28.6
       '@babel/types': 7.29.0
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.1
@@ -6098,7 +6191,7 @@ snapshots:
 
   '@types/babel__template@7.4.1':
     dependencies:
-      '@babel/parser': 7.27.0
+      '@babel/parser': 7.28.6
       '@babel/types': 7.29.0
 
   '@types/babel__traverse@7.28.0':
@@ -6156,6 +6249,8 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.12
       csstype: 3.1.3
+
+  '@types/resolve@1.20.6': {}
 
   '@types/semver@6.2.3': {}
 
@@ -6419,6 +6514,53 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@unrs/rspack-resolver-binding-darwin-arm64@1.3.0':
+    optional: true
+
+  '@unrs/rspack-resolver-binding-darwin-x64@1.3.0':
+    optional: true
+
+  '@unrs/rspack-resolver-binding-freebsd-x64@1.3.0':
+    optional: true
+
+  '@unrs/rspack-resolver-binding-linux-arm-gnueabihf@1.3.0':
+    optional: true
+
+  '@unrs/rspack-resolver-binding-linux-arm-musleabihf@1.3.0':
+    optional: true
+
+  '@unrs/rspack-resolver-binding-linux-arm64-gnu@1.3.0':
+    optional: true
+
+  '@unrs/rspack-resolver-binding-linux-arm64-musl@1.3.0':
+    optional: true
+
+  '@unrs/rspack-resolver-binding-linux-ppc64-gnu@1.3.0':
+    optional: true
+
+  '@unrs/rspack-resolver-binding-linux-s390x-gnu@1.3.0':
+    optional: true
+
+  '@unrs/rspack-resolver-binding-linux-x64-gnu@1.3.0':
+    optional: true
+
+  '@unrs/rspack-resolver-binding-linux-x64-musl@1.3.0':
+    optional: true
+
+  '@unrs/rspack-resolver-binding-wasm32-wasi@1.3.0':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.12
+    optional: true
+
+  '@unrs/rspack-resolver-binding-win32-arm64-msvc@1.3.0':
+    optional: true
+
+  '@unrs/rspack-resolver-binding-win32-ia32-msvc@1.3.0':
+    optional: true
+
+  '@unrs/rspack-resolver-binding-win32-x64-msvc@1.3.0':
+    optional: true
+
   '@wry/equality@0.1.11':
     dependencies:
       tslib: 1.14.1
@@ -6676,7 +6818,7 @@ snapshots:
       babel-plugin-istanbul: 6.1.1
       babel-preset-jest: 27.5.1(@babel/core@7.26.10)
       chalk: 4.1.2
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.11
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
@@ -6718,7 +6860,7 @@ snapshots:
 
   babel-plugin-jest-hoist@27.5.1:
     dependencies:
-      '@babel/template': 7.27.0
+      '@babel/template': 7.28.6
       '@babel/types': 7.29.0
       '@types/babel__core': 7.1.18
       '@types/babel__traverse': 7.28.0
@@ -6765,24 +6907,24 @@ snapshots:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.26.10)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.26.10)
 
-  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.0):
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.6):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
+      '@babel/core': 7.28.6
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.6)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.6)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.6)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.6)
+      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.28.6)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.6)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.6)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.6)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.6)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.6)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.6)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.6)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.6)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.6)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.6)
 
   babel-preset-jest@23.2.0:
     dependencies:
@@ -6972,7 +7114,7 @@ snapshots:
 
   ci-info@3.3.0: {}
 
-  ci-info@4.4.0: {}
+  ci-info@4.3.1: {}
 
   cjs-module-lexer@1.2.2: {}
 
@@ -7769,8 +7911,6 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  function-bind@1.1.1: {}
-
   function-bind@1.1.2: {}
 
   function.prototype.name@1.1.8:
@@ -7914,10 +8054,6 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  has@1.0.3:
-    dependencies:
-      function-bind: 1.1.1
-
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
@@ -8038,10 +8174,6 @@ snapshots:
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.2
-
-  is-core-module@2.8.1:
-    dependencies:
-      has: 1.0.3
 
   is-data-view@1.0.2:
     dependencies:
@@ -8198,7 +8330,7 @@ snapshots:
 
   istanbul-lib-instrument@5.1.0:
     dependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.28.6
       '@babel/parser': 7.27.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
@@ -8208,8 +8340,8 @@ snapshots:
 
   istanbul-lib-instrument@6.0.3:
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/parser': 7.27.0
+      '@babel/core': 7.28.6
+      '@babel/parser': 7.28.6
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 7.7.3
@@ -8224,7 +8356,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.3.5
+      debug: 4.4.3
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -8494,7 +8626,7 @@ snapshots:
 
   jest-message-util@30.2.0:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.28.6
       '@jest/types': 30.2.0
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -8540,7 +8672,7 @@ snapshots:
       jest-pnp-resolver: 1.2.2(jest-resolve@27.5.1)
       jest-util: 27.5.1
       jest-validate: 27.5.1
-      resolve: 1.22.0
+      resolve: 1.22.11
       resolve.exports: 1.1.0
       slash: 3.0.0
 
@@ -8603,7 +8735,7 @@ snapshots:
   jest-serializer@27.5.1:
     dependencies:
       '@types/node': 17.0.21
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.11
 
   jest-snapshot@27.5.1:
     dependencies:
@@ -8634,17 +8766,17 @@ snapshots:
 
   jest-snapshot@30.2.0:
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.28.6
+      '@babel/generator': 7.28.6
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.28.6)
       '@babel/types': 7.29.0
       '@jest/expect-utils': 30.2.0
       '@jest/get-type': 30.1.0
       '@jest/snapshot-utils': 30.2.0
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.6)
       chalk: 4.1.2
       expect: 30.2.0
       graceful-fs: 4.2.11
@@ -8681,7 +8813,7 @@ snapshots:
       '@jest/types': 30.2.0
       '@types/node': 17.0.21
       chalk: 4.1.2
-      ci-info: 4.4.0
+      ci-info: 4.3.1
       graceful-fs: 4.2.11
       picomatch: 4.0.3
 
@@ -8842,7 +8974,7 @@ snapshots:
 
   load-json-file@1.1.0:
     dependencies:
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.11
       parse-json: 2.2.0
       pify: 2.3.0
       pinkie-promise: 2.0.1
@@ -9012,7 +9144,7 @@ snapshots:
   normalize-package-data@2.5.0:
     dependencies:
       hosted-git-info: 2.8.9
-      resolve: 1.22.0
+      resolve: 1.22.11
       semver: 5.7.1
       validate-npm-package-license: 3.0.4
 
@@ -9187,7 +9319,7 @@ snapshots:
 
   path-type@1.1.0:
     dependencies:
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.11
       pify: 2.3.0
       pinkie-promise: 2.0.1
 
@@ -9447,12 +9579,6 @@ snapshots:
 
   resolve.exports@1.1.0: {}
 
-  resolve@1.22.0:
-    dependencies:
-      is-core-module: 2.8.1
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
-
   resolve@1.22.11:
     dependencies:
       is-core-module: 2.16.1
@@ -9470,6 +9596,24 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.0
+
+  rspack-resolver@1.3.0:
+    optionalDependencies:
+      '@unrs/rspack-resolver-binding-darwin-arm64': 1.3.0
+      '@unrs/rspack-resolver-binding-darwin-x64': 1.3.0
+      '@unrs/rspack-resolver-binding-freebsd-x64': 1.3.0
+      '@unrs/rspack-resolver-binding-linux-arm-gnueabihf': 1.3.0
+      '@unrs/rspack-resolver-binding-linux-arm-musleabihf': 1.3.0
+      '@unrs/rspack-resolver-binding-linux-arm64-gnu': 1.3.0
+      '@unrs/rspack-resolver-binding-linux-arm64-musl': 1.3.0
+      '@unrs/rspack-resolver-binding-linux-ppc64-gnu': 1.3.0
+      '@unrs/rspack-resolver-binding-linux-s390x-gnu': 1.3.0
+      '@unrs/rspack-resolver-binding-linux-x64-gnu': 1.3.0
+      '@unrs/rspack-resolver-binding-linux-x64-musl': 1.3.0
+      '@unrs/rspack-resolver-binding-wasm32-wasi': 1.3.0
+      '@unrs/rspack-resolver-binding-win32-arm64-msvc': 1.3.0
+      '@unrs/rspack-resolver-binding-win32-ia32-msvc': 1.3.0
+      '@unrs/rspack-resolver-binding-win32-x64-msvc': 1.3.0
 
   run-parallel@1.2.0:
     dependencies:
@@ -9847,6 +9991,12 @@ snapshots:
     dependencies:
       '@types/json5': 0.0.29
       json5: 1.0.2
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       minimist:
         specifier: ^1.2.8
         version: 1.2.8
-      resolve:
-        specifier: ^1.22.8
-        version: 1.22.11
       rspack-resolver:
         specifier: ^1.3.0
         version: 1.3.0
@@ -90,9 +87,6 @@ importers:
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.3
-      '@types/resolve':
-        specifier: ^1.20.6
-        version: 1.20.6
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.17.0
         version: 7.17.0(@typescript-eslint/parser@7.17.0(eslint@8.57.0)(typescript@5.1.6))(eslint@8.57.0)(typescript@5.1.6)
@@ -1236,9 +1230,6 @@ packages:
 
   '@types/react@18.3.3':
     resolution: {integrity: sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==}
-
-  '@types/resolve@1.20.6':
-    resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
   '@types/semver@6.2.3':
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
@@ -6249,8 +6240,6 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.12
       csstype: 3.1.3
-
-  '@types/resolve@1.20.6': {}
 
   '@types/semver@6.2.3': {}
 

--- a/schema.json
+++ b/schema.json
@@ -94,23 +94,7 @@
         "generate": {"oneOf": [
             {"$ref": "#/definitions/GenerateConfig"},
             {"type": "array", "items": {"$ref": "#/definitions/GenerateConfig"}}
-        ]},
-        "alias": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "find": {
-                        "type": ["string", "object"]
-                    },
-                    "replacement": {
-                        "type": "string"
-                    }
-                },
-                "required": [ "find", "replacement" ]
-            }
-        }
+        ]}
     },
     "required": [ "crawl", "generate" ]
 }

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -56,7 +56,7 @@ const inputFiles = getInputFiles(options, config);
 /** Step (2) */
 
 const files = processFiles(inputFiles, config, (f) => {
-    const resolvedPath = getPathWithExtension(f, config);
+    const resolvedPath = getPathWithExtension(f);
     if (!resolvedPath) {
         throw new Error(`Unable to find ${f}`);
     }

--- a/src/parser/__test__/parse.test.ts
+++ b/src/parser/__test__/parse.test.ts
@@ -1,10 +1,39 @@
-import {describe, it, expect} from "@jest/globals";
+/**
+ * @jest-environment node
+ */
+import {describe, it, expect, afterEach} from "@jest/globals";
 
 import {Config} from "../../types";
 import {processFiles} from "../parse";
 import {resolveDocuments} from "../resolve";
 
 import {print} from "graphql/language/printer";
+
+jest.mock("../resolveImport", () => ({
+    resetImportCache: jest.fn(),
+    resolveImportPath: jest
+        .fn()
+        .mockImplementation((sourceFile: string, importPath: string) => {
+            const path = require("path");
+            if (importPath === "graphql-tag") {
+                return "/repo/node_modules/graphql-tag/index.js";
+            }
+            if (importPath === "monorepo-package/fragment") {
+                return "/repo/node_modules/monorepo-package/fragment.js";
+            }
+            if (importPath.startsWith(".")) {
+                return path.resolve(path.dirname(sourceFile), importPath);
+            }
+            if (path.isAbsolute(importPath)) {
+                return importPath;
+            }
+            return null;
+        }),
+}));
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
 
 const fixtureFiles: {
     [key: string]:
@@ -14,6 +43,27 @@ const fixtureFiles: {
               resolvedPath: string;
           };
 } = {
+    "/repo/node_modules/monorepo-package/fragment.js": `
+        import gql from 'graphql-tag';
+
+        export const sharedFragment = gql\`
+        fragment SharedFields on Something {
+            id
+        }
+        \`;
+    `,
+    "/repo/packages/app/App.js": `
+        import gql from 'graphql-tag';
+        import {sharedFragment} from 'monorepo-package/fragment';
+        export const appQuery = gql\`
+        query AppQuery {
+            viewer {
+                ...SharedFields
+            }
+        }
+        \${sharedFragment}
+        \`;
+    `,
     "/firstFile.js": `
         // Note that you can import graphql-tag as
         // something other than gql.
@@ -421,5 +471,65 @@ describe("processing fragments in various ways", () => {
             }",
             }
         `);
+    });
+
+    it("should resolve fragments imported from monorepo packages", () => {
+        // Arrange
+        const config: Config = {
+            crawl: {
+                root: "/here/we/crawl",
+            },
+            generate: {
+                match: [/\.fixture\.js$/],
+                exclude: [
+                    "_test\\.js$",
+                    "\\bcourse-editor-package\\b",
+                    "\\.fixture\\.js$",
+                    "\\b__flowtests__\\b",
+                    "\\bcourse-editor\\b",
+                ],
+                readOnlyArray: false,
+                regenerateCommand: "make gqlflow",
+                scalars: {
+                    JSONString: "string",
+                    KALocale: "string",
+                    NaiveDateTime: "string",
+                },
+                splitTypes: true,
+                generatedDirectory: "__graphql-types__",
+                exportAllObjectTypes: true,
+                schemaFilePath: "./composed_schema.graphql",
+            },
+        };
+
+        // Act
+        const files = processFiles(
+            ["/repo/packages/app/App.js"],
+            config,
+            getFileSource,
+        );
+        const {resolved} = resolveDocuments(files, config);
+        const printed: Record<string, any> = {};
+        Object.keys(resolved).map(
+            (k: any) => (printed[k] = print(resolved[k].document).trim()),
+        );
+
+        // Assert
+        expect(printed).toMatchInlineSnapshot(`
+                Object {
+                  "/repo/node_modules/monorepo-package/fragment.js:4": "fragment SharedFields on Something {
+                  id
+                }",
+                  "/repo/packages/app/App.js:4": "query AppQuery {
+                  viewer {
+                    ...SharedFields
+                  }
+                }
+
+                fragment SharedFields on Something {
+                  id
+                }",
+                }
+            `);
     });
 });

--- a/src/parser/__test__/resolveImport.test.ts
+++ b/src/parser/__test__/resolveImport.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment node
+ */
+import {afterEach, beforeEach, describe, expect, it} from "@jest/globals";
+import {resolveImportPath, resetImportCache} from "../resolveImport";
+import {ResolverFactory} from "rspack-resolver";
+
+const mockSync = jest.fn();
+const mockCreateMatchPath = jest.fn();
+const mockLoadConfig = jest.fn();
+
+jest.mock("rspack-resolver", () => ({
+    ResolverFactory: jest.fn().mockImplementation(() => ({
+        sync: (...args: Array<unknown>) => mockSync(...args),
+    })),
+}));
+
+jest.mock("tsconfig-paths", () => ({
+    createMatchPath: jest
+        .fn()
+        .mockImplementation((...args: Array<unknown>) =>
+            mockCreateMatchPath(...args),
+        ),
+    loadConfig: jest
+        .fn()
+        .mockImplementation((...args: Array<unknown>) =>
+            mockLoadConfig(...args),
+        ),
+}));
+
+describe("resolveImportPath", () => {
+    beforeEach(() => {
+        mockSync.mockReset();
+        mockCreateMatchPath.mockReset();
+        mockLoadConfig.mockReset();
+        (ResolverFactory as unknown as jest.Mock).mockClear();
+        resetImportCache();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("returns the resolved path from the resolver", () => {
+        // Arrange
+        const matchPath = jest.fn().mockReturnValue("/repo/src/alias/thing.ts");
+        mockLoadConfig.mockReturnValue({
+            resultType: "success",
+            absoluteBaseUrl: "/repo",
+            paths: {"@/*": ["src/*"]},
+        });
+        mockCreateMatchPath.mockReturnValue(matchPath);
+        mockSync.mockReturnValue({path: "/repo/src/alias/thing.ts"});
+
+        // Act
+        const result = resolveImportPath("/repo/src/file.ts", "@/alias/thing");
+
+        // Assert
+        expect(result).toBe("/repo/src/alias/thing.ts");
+    });
+
+    it("loads tsconfig from the source file directory", () => {
+        // Arrange
+        const matchPath = jest.fn().mockReturnValue("/repo/src/alias/thing.ts");
+        mockLoadConfig.mockReturnValue({
+            resultType: "success",
+            absoluteBaseUrl: "/repo",
+            paths: {"@/*": ["src/*"]},
+        });
+        mockCreateMatchPath.mockReturnValue(matchPath);
+        mockSync.mockReturnValue({path: "/repo/src/alias/thing.ts"});
+
+        // Act
+        resolveImportPath("/repo/src/file.ts", "@/alias/thing");
+
+        // Assert
+        expect(mockLoadConfig).toHaveBeenCalledWith("/repo/src");
+    });
+
+    it("caches tsconfig matchPath per source directory", () => {
+        // Arrange
+        const matchPath = jest.fn().mockReturnValue(undefined);
+        mockLoadConfig.mockReturnValue({
+            resultType: "success",
+            absoluteBaseUrl: "/repo",
+            paths: {},
+        });
+        mockCreateMatchPath.mockReturnValue(matchPath);
+        mockSync.mockReturnValue({path: "/repo/node_modules/pkg/index.js"});
+
+        // Act
+        resolveImportPath("/repo/src/a.ts", "pkg");
+        resolveImportPath("/repo/src/b.ts", "pkg");
+
+        // Assert
+        expect(mockLoadConfig).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/parser/__test__/utils.test.ts
+++ b/src/parser/__test__/utils.test.ts
@@ -1,40 +1,9 @@
+/**
+ * @jest-environment node
+ */
 import fs from "fs";
-import {describe, it, expect, jest} from "@jest/globals";
-import type {Config} from "../../types";
-
+import {describe, it, expect} from "@jest/globals";
 import {getPathWithExtension} from "../utils";
-
-const generate = {
-    match: [/\.fixture\.js$/],
-    exclude: [
-        "_test\\.js$",
-        "\\bcourse-editor-package\\b",
-        "\\.fixture\\.js$",
-        "\\b__flowtests__\\b",
-        "\\bcourse-editor\\b",
-    ],
-    readOnlyArray: false,
-    regenerateCommand: "make gqlflow",
-    scalars: {
-        JSONString: "string",
-        KALocale: "string",
-        NaiveDateTime: "string",
-    },
-    splitTypes: true,
-    generatedDirectory: "__graphql-types__",
-    exportAllObjectTypes: true,
-    schemaFilePath: "./composed_schema.graphql",
-} as const;
-
-const config: Config = {
-    crawl: {
-        root: "/here/we/crawl",
-    },
-    generate: [
-        {...generate, match: [/^static/], exportAllObjectTypes: false},
-        generate,
-    ],
-};
 
 describe("getPathWithExtension", () => {
     it("should handle a basic missing extension", () => {
@@ -44,7 +13,7 @@ describe("getPathWithExtension", () => {
         );
 
         // Act
-        const result = getPathWithExtension("/path/to/file", config);
+        const result = getPathWithExtension("/path/to/file");
 
         // Assert
         expect(result).toBe("/path/to/file.js");
@@ -55,26 +24,20 @@ describe("getPathWithExtension", () => {
         jest.spyOn(fs, "existsSync").mockImplementation((path) => false);
 
         // Act
-        const result = getPathWithExtension("/path/to/file", config);
+        const result = getPathWithExtension("/path/to/file");
 
         // Assert
         expect(result).toBe(null);
     });
 
-    it("maps aliases to their correct value", () => {
+    it("returns the original path when an extension is already present", () => {
         // Arrange
-        jest.spyOn(fs, "existsSync").mockImplementation((path) =>
-            typeof path === "string" ? path.endsWith(".js") : false,
-        );
-        const tmpConfig: Config = {
-            ...config,
-            alias: [{find: "~", replacement: "../../some/prefix"}],
-        };
+        const input = "/dir/file.tsx";
 
         // Act
-        const result = getPathWithExtension("~/dir/file", tmpConfig);
+        const result = getPathWithExtension(input);
 
         // Assert
-        expect(result).toBe("../../some/prefix/dir/file.js");
+        expect(result).toBe(input);
     });
 });

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -8,10 +8,12 @@ import type {
 
 import {parse, ParserPlugin} from "@babel/parser";
 import traverse from "@babel/traverse";
+import type {NodePath} from "@babel/traverse";
 
 import path from "path";
 
-import {fixPathResolution, getPathWithExtension} from "./utils";
+import {resolveImportPath} from "./resolveImport";
+import {getPathWithExtension} from "./utils";
 import {Config} from "../types";
 
 /**
@@ -63,6 +65,8 @@ export type Import = {
     type: "import";
     name: string;
     path: string;
+    rawPath?: string;
+    resolvedPath?: string | null;
     loc: Loc;
 };
 
@@ -101,15 +105,12 @@ export type Files = {
  * potentially relevant, and of course any values referenced
  * from a graphql template are treated as relevant.
  */
-const listExternalReferences = (
-    file: FileResult,
-    config: Config,
-): Array<string> => {
+const listExternalReferences = (file: FileResult): Array<string> => {
     const paths: Record<string, any> = {};
     const add = (v: Document | Import, followImports: boolean) => {
         if (v.type === "import") {
             if (followImports) {
-                const absPath = getPathWithExtension(v.path, config);
+                const absPath = getPathWithExtension(v.path);
                 if (absPath) {
                     paths[absPath] = true;
                 }
@@ -156,7 +157,6 @@ export const processFile = (
           },
     config: Config,
 ): FileResult => {
-    const dir = path.dirname(filePath);
     const result: FileResult = {
         path: filePath,
         operations: [],
@@ -181,17 +181,20 @@ export const processFile = (
 
     ast.program.body.forEach((toplevel) => {
         if (toplevel.type === "ImportDeclaration") {
-            const newLocals = getLocals(dir, toplevel, filePath, config);
+            const newLocals = getLocals(toplevel, filePath);
             if (newLocals) {
                 Object.keys(newLocals).forEach((k) => {
                     const local = newLocals[k];
-                    if (local.path.startsWith("/")) {
+                    const isGraphqlTagImport =
+                        local.rawPath === "graphql-tag" ||
+                        (local.resolvedPath?.includes(
+                            `${path.sep}node_modules${path.sep}graphql-tag`,
+                        ) ??
+                            false);
+                    if (path.isAbsolute(local.path)) {
                         result.locals[k] = local;
                     }
-                    if (
-                        local.path === "graphql-tag" &&
-                        local.name === "default"
-                    ) {
+                    if (isGraphqlTagImport && local.name === "default") {
                         gqlTagNames.push(k);
                     }
                 });
@@ -200,9 +203,8 @@ export const processFile = (
         if (toplevel.type === "ExportNamedDeclaration") {
             if (toplevel.source) {
                 const source = toplevel.source;
-                const importPath = source.value.startsWith(".")
-                    ? path.resolve(path.join(dir, source.value))
-                    : source.value;
+                const resolvedPath = resolveImportPath(filePath, source.value);
+                const importPath = resolvedPath ?? source.value;
                 toplevel.specifiers?.forEach((spec) => {
                     if (
                         spec.type === "ExportSpecifier" &&
@@ -328,8 +330,9 @@ export const processFile = (
     };
 
     traverse(ast as any, {
-        TaggedTemplateExpression(path) {
-            visitTpl(path.node as any, (name) => {
+        TaggedTemplateExpression(path: NodePath) {
+            const node = path.node as TaggedTemplateExpression;
+            visitTpl(node, (name) => {
                 const binding = path.scope.getBinding(name);
                 if (!binding) {
                     return null;
@@ -404,10 +407,8 @@ const processTemplate = (
 };
 
 const getLocals = (
-    dir: string,
     toplevel: ImportDeclaration,
     myPath: string,
-    config: Config,
 ):
     | {
           [key: string]: Import;
@@ -417,10 +418,8 @@ const getLocals = (
     if (toplevel.importKind === "type") {
         return null;
     }
-    const fixedPath = fixPathResolution(toplevel.source.value, config);
-    const importPath = fixedPath.startsWith(".")
-        ? path.resolve(path.join(dir, fixedPath))
-        : fixedPath;
+    const resolvedPath = resolveImportPath(myPath, toplevel.source.value);
+    const importPath = resolvedPath ?? toplevel.source.value;
     const locals: Record<string, any> = {};
     toplevel.specifiers.forEach((spec) => {
         if (spec.type === "ImportDefaultSpecifier") {
@@ -428,6 +427,8 @@ const getLocals = (
                 type: "import",
                 name: "default",
                 path: importPath,
+                rawPath: toplevel.source.value,
+                resolvedPath,
                 loc: {start: spec.start, end: spec.end, path: myPath},
             };
         } else if (spec.type === "ImportSpecifier") {
@@ -438,6 +439,8 @@ const getLocals = (
                         ? spec.imported.name
                         : spec.imported.value,
                 path: importPath,
+                rawPath: toplevel.source.value,
+                resolvedPath,
                 loc: {start: spec.start, end: spec.end, path: myPath},
             };
         }
@@ -469,7 +472,7 @@ export const processFiles = (
         }
         const result = processFile(next, source, config);
         files[next] = result;
-        listExternalReferences(result, config).forEach((path) => {
+        listExternalReferences(result).forEach((path) => {
             if (!files[path] && !toProcess.includes(path)) {
                 toProcess.push(path);
             }

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -237,7 +237,7 @@ export const processFile = (
         if (toplevel.type === "ExportAllDeclaration" && toplevel.source) {
             const source = toplevel.source;
             const importPath = source.value.startsWith(".")
-                ? path.resolve(path.join(dir, source.value))
+                ? path.resolve(path.join(path.dirname(filePath), source.value))
                 : source.value;
             result.exportAlls.push({
                 type: "import",

--- a/src/parser/resolve.ts
+++ b/src/parser/resolve.ts
@@ -51,7 +51,7 @@ const resolveImport = (
     },
     config: Config,
 ): Document | null | undefined => {
-    const absPath = getPathWithExtension(expr.path, config);
+    const absPath = getPathWithExtension(expr.path);
     if (!absPath) {
         return null;
     }

--- a/src/parser/resolveImport.ts
+++ b/src/parser/resolveImport.ts
@@ -1,0 +1,64 @@
+// Copied from https://github.com/Khan/frontend/blob/main/libs/node/resolve-import/src/resolve-import.ts
+// In future it would be cool to publish @khan/node-resolve-import as a public library so we
+// could consume it here.
+import path from "node:path";
+
+import {ResolverFactory} from "rspack-resolver";
+import {createMatchPath, loadConfig} from "tsconfig-paths";
+
+const CONDITION_NAMES = ["import"];
+
+const matchPathCache = new Map<
+    string,
+    (importPath: string) => string | undefined
+>();
+
+let esmResolver = getEsmResolver();
+
+function getEsmResolver() {
+    return new ResolverFactory({
+        conditionNames: CONDITION_NAMES,
+        mainFields: ["module", "main"],
+    });
+}
+
+export function resetImportCache() {
+    matchPathCache.clear();
+    esmResolver = getEsmResolver();
+}
+
+/**
+ * Resolves an import path using tsconfig and the rspack resolver.
+ *
+ * @param sourceFile - The file that is importing the path.
+ * @param importPath - The path to resolve.
+ * @returns The fully resolved path.
+ */
+export function resolveImportPath(sourceFile: string, importPath: string) {
+    const dir = path.dirname(sourceFile);
+    let matchPath = matchPathCache.get(dir);
+
+    if (!matchPath) {
+        const foundConfig = loadConfig(dir);
+
+        if (foundConfig.resultType !== "success") {
+            throw new Error("Failed to load tsconfig");
+        }
+
+        matchPath = createMatchPath(
+            foundConfig.absoluteBaseUrl,
+            foundConfig.paths,
+            CONDITION_NAMES,
+        );
+        matchPathCache.set(dir, matchPath);
+    }
+
+    // See if we can resolve the import path using the tsconfig.
+    const resolvedPath = matchPath(importPath);
+
+    // Get the directory of the source file to resolve against.
+    const sourceFileDir = path.dirname(sourceFile);
+
+    // Get the fully resolved path.
+    return esmResolver.sync(sourceFileDir, resolvedPath ?? importPath).path;
+}

--- a/src/parser/resolveImport.ts
+++ b/src/parser/resolveImport.ts
@@ -19,6 +19,7 @@ function getEsmResolver() {
     return new ResolverFactory({
         conditionNames: CONDITION_NAMES,
         mainFields: ["module", "main"],
+        extensions: [".mjs", ".js", ".jsx", ".ts", ".tsx"],
     });
 }
 

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -1,20 +1,6 @@
 import fs from "fs";
-import {Config} from "../types";
 
-export const fixPathResolution = (path: string, config: Config) => {
-    if (config.alias) {
-        for (const {find, replacement} of config.alias) {
-            path = path.replace(find, replacement);
-        }
-    }
-    return path;
-};
-
-export const getPathWithExtension = (
-    pathWithoutExtension: string,
-    config: Config,
-) => {
-    pathWithoutExtension = fixPathResolution(pathWithoutExtension, config);
+export const getPathWithExtension = (pathWithoutExtension: string) => {
     if (
         /\.(less|css|png|gif|jpg|jpeg|js|jsx|ts|tsx|mjs)$/.test(
             pathWithoutExtension,

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,10 +50,6 @@ export type CrawlConfig = {
 export type Config = {
     crawl: CrawlConfig;
     generate: GenerateConfig | Array<GenerateConfig>;
-    alias?: Array<{
-        find: RegExp | string;
-        replacement: string;
-    }>;
 };
 
 export type Schema = {


### PR DESCRIPTION
## Summary:
This PR replaces ad-hoc import path handling with a centralized `resolveImportPath` resolver that understands tsconfig path aliases and package/module resolution. This enables fragment imports across monorepo package boundaries (and into third-party non-transpiled pacakges) and makes import handling more consistent across parsing and resolution flows.

**What changed**
- Added `src/parser/resolveImport.ts`:
  - this is copied from the `frontend` repo's `libs/node/resolve-import`
- Updated parser flow to use `resolveImportPath` for imports/exports:
  - Import declarations
  - Export-from declarations
  - GraphQL tag detection now recognizes resolved `graphql-tag` paths in `node_modules`.
- Simplified path utility usage:
  - `getPathWithExtension` no longer takes config alias mappings.
  - Removed legacy alias-based config support from:
    - `src/types.ts`
    - `schema.json`
    - `src/parser/utils.ts`
    - call sites (`src/cli/run.ts`, parser/resolve paths)
- Added/updated tests:
  - New unit tests for resolver behavior in `src/parser/__test__/resolveImport.test.ts`
  - Parse test coverage for monorepo package fragment imports
  - Updated utils tests for new `getPathWithExtension` signature
  - Added node test environment declarations where needed
- Dependency updates in `package.json` / `pnpm-lock.yaml` for resolver and test typing/runtime support.

**Behavioral impact**
- Imports like `import {frag} from "monorepo-packagfragment"` now resolve correctly when resolver/tsconfig mapping supports them.
- Parser/import resolution no longer depends on legacy `alias` config rewrite behavior.
- More deterministic import handling between parse-time references and file crawling.

Issue: none

## Test plan:
see tests. also try running this in the frontend repo, and you'll see that we already have a package fragment import that was going unnoticed, and unsupported! So that's fun.
```sh
pnpm run build
cd ../frontend
../graphql-flow/dist/cli/run.js ./dev/graphql-flow/config.js
```