### PR TITLE
Merge sub-selections when the same response name appears across query branches

### DIFF
--- a/.changeset/merge-overlapping-field-selections.md
+++ b/.changeset/merge-overlapping-field-selections.md
@@ -1,0 +1,25 @@
+---
+"@khanacademy/graphql-flow": major
+---
+
+Merge sub-selections when the same response name is selected through multiple branches (base level + inline fragment, two fragment spreads, etc.) so the generated TypeScript matches what the server actually returns.
+
+**Bug fix.** Previously, a query like
+
+```graphql
+hero {
+  friends { id }
+  ... on Human {
+    friends { name }
+  }
+}
+```
+
+generated a `Human.friends` type containing only `name` — the `id` selection from the base level was silently dropped. graphql-flow now mirrors the GraphQL spec's CollectFields behavior and merges the two `friends` selections, producing `{ id; name }`.
+
+**Behavior change (why this is a major bump):** For queries that mix inline fragments with base-level field selections on an interface, the field-lookup base is now the concrete impl rather than the interface itself. In practice this means:
+
+- JSDoc description comments on fields now come from the concrete impl (e.g. `Human.name`'s description shows up where previously only the bare interface field appeared).
+- If any of your interfaces declare covariant field overrides (a concrete impl narrowing the interface's field type), generated types for those fields will now reflect the concrete impl's narrower type when accessed through a fragment refinement on that impl. Runtime data was already this shape; the type is just catching up.
+
+If you depend on the exact previous output (e.g. snapshot tests of generated `.ts` files), expect diffs in interface-with-fragment queries. Regenerate types and review.

--- a/src/__test__/graphql-flow.test.ts
+++ b/src/__test__/graphql-flow.test.ts
@@ -233,7 +233,7 @@ describe("graphql-flow generation", () => {
                   } | null | undefined> | null | undefined;
                   hands: number | null | undefined;
                   id: string;
-                  name: string | null | undefined;
+                  /** The person's name*/name: string | null | undefined;
                 } | null | undefined> | null | undefined;
                 hands: number | null | undefined;
                 homePlanet: string | null | undefined;
@@ -402,7 +402,7 @@ describe("graphql-flow generation", () => {
                 } | {
                   __typename: "Human";
                   homePlanet: string | null | undefined;
-                  name: string | null | undefined;
+                  /** The person's name*/name: string | null | undefined;
                 };
             `);
         });
@@ -549,6 +549,163 @@ describe("graphql-flow generation", () => {
                   human: /** A human character*/{
                     id: string;
                     /** The person's name*/name: string | null | undefined;
+                  } | null | undefined;
+                }
+                };
+            `);
+        });
+
+        it("should merge sub-selections when the same field appears at the base level and in a matching inline fragment", () => {
+            const result = rawQueryToFlowTypes(
+                `
+                query SomeQuery {
+                    human(id: "x") {
+                        friends { id }
+                        ... on Human {
+                            friends { name }
+                        }
+                    }
+                }`,
+                {readOnlyArray: false},
+            );
+            expect(result).toMatchInlineSnapshot(`
+                // SomeQueryType.js
+                export type SomeQueryType = {
+                    variables: {},
+                    response: {
+                  human: /** A human character*/{
+                    friends: Array<{
+                      id: string;
+                      name: string | null | undefined;
+                    } | null | undefined> | null | undefined;
+                  } | null | undefined;
+                }
+                };
+            `);
+        });
+
+        it("should merge sub-selections when the same field is contributed by a fragment spread and the base level", () => {
+            const result = rawQueryToFlowTypes(
+                `
+                fragment HumanFriendsIds on Human {
+                    friends { id }
+                }
+                query SomeQuery {
+                    human(id: "x") {
+                        ...HumanFriendsIds
+                        friends { name }
+                    }
+                }`,
+                {readOnlyArray: false},
+            );
+            expect(result).toMatchInlineSnapshot(`
+                // HumanFriendsIds.js
+                export type HumanFriendsIds = {
+                  friends: Array<{
+                    id: string;
+                  } | null | undefined> | null | undefined;
+                };
+
+                // SomeQueryType.js
+                export type SomeQueryType = {
+                    variables: {},
+                    response: {
+                  human: /** A human character*/{
+                    friends: Array<{
+                      id: string;
+                      name: string | null | undefined;
+                    } | null | undefined> | null | undefined;
+                  } | null | undefined;
+                }
+                };
+            `);
+        });
+
+        it("should merge sub-selections on an interface when the same field appears at the base level and inside an inline fragment on a concrete impl", () => {
+            const result = rawQueryToFlowTypes(
+                `
+                query SomeQuery {
+                    hero(episode: JEDI) {
+                        id
+                        friends { id }
+                        ... on Human {
+                            friends { name }
+                            homePlanet
+                        }
+                        ... on Droid {
+                            primaryFunction
+                        }
+                    }
+                }`,
+                {readOnlyArray: false},
+            );
+            expect(result).toMatchInlineSnapshot(`
+                // SomeQueryType.js
+                export type SomeQueryType = {
+                    variables: {},
+                    response: {
+                  hero: {
+                    friends: Array<{
+                      id: string;
+                    } | null | undefined> | null | undefined;
+                    id: string;
+                    /** The robot's primary function*/primaryFunction: string;
+                  } | {
+                    friends: Array<{
+                      id: string;
+                      name: string | null | undefined;
+                    } | null | undefined> | null | undefined;
+                    homePlanet: string | null | undefined;
+                    id: string;
+                  } | null | undefined;
+                }
+                };
+            `);
+        });
+
+        it("should leave unions on the existing per-selection flow (no accidental field merging across variants)", () => {
+            // Unions don't allow base-level Field selections (other than
+            // __typename), so the response-name merge in objectPropertiesToFlow
+            // shouldn't activate here. Each inline fragment's selections must
+            // stay scoped to its own variant.
+            const result = rawQueryToFlowTypes(
+                `
+                fragment HumanName on Human {
+                    name
+                }
+                query SomeQuery {
+                    friend(id: "x") {
+                        __typename
+                        ...HumanName
+                        ... on Human {
+                            hands
+                        }
+                        ... on Droid {
+                            primaryFunction
+                        }
+                    }
+                }`,
+                {readOnlyArray: false},
+            );
+            expect(result).toMatchInlineSnapshot(`
+                // HumanName.js
+                export type HumanName = {
+                  /** The person's name*/name: string | null | undefined;
+                };
+
+                // SomeQueryType.js
+                export type SomeQueryType = {
+                    variables: {},
+                    response: {
+                  friend: {
+                    __typename: "Animal";
+                  } | {
+                    __typename: "Droid";
+                    /** The robot's primary function*/primaryFunction: string;
+                  } | {
+                    __typename: "Human";
+                    hands: number | null | undefined;
+                    name: string | null | undefined;
                   } | null | undefined;
                 }
                 };

--- a/src/__test__/graphql-flow.test.ts
+++ b/src/__test__/graphql-flow.test.ts
@@ -626,6 +626,7 @@ describe("graphql-flow generation", () => {
                 `
                 query SomeQuery {
                     hero(episode: JEDI) {
+                        __typename
                         id
                         friends { id }
                         ... on Human {
@@ -645,12 +646,14 @@ describe("graphql-flow generation", () => {
                     variables: {},
                     response: {
                   hero: {
+                    __typename: "Droid";
                     friends: Array<{
                       id: string;
                     } | null | undefined> | null | undefined;
                     id: string;
                     /** The robot's primary function*/primaryFunction: string;
                   } | {
+                    __typename: "Human";
                     friends: Array<{
                       id: string;
                       name: string | null | undefined;

--- a/src/generateResponseType.ts
+++ b/src/generateResponseType.ts
@@ -8,7 +8,9 @@ import type {
     OperationDefinitionNode,
     FragmentDefinitionNode,
     SelectionNode,
+    SelectionSetNode,
 } from "graphql";
+import {Kind} from "graphql";
 import type {Context, Schema, Selections} from "./types";
 import {
     liftLeadingPropertyComments,
@@ -242,6 +244,86 @@ const querySelectionToObjectType = (
     );
 };
 
+// Mirrors the spec's CollectFields algorithm: when the same response name
+// appears more than once in a selection set, the GraphQL execution merges
+// their sub-selections rather than picking one. Without this, a base-level
+// `foo { a }` plus an inline-fragment `foo { b }` would produce two property
+// signatures and the second silently clobbers the first in the output type.
+const mergeFieldsByResponseName = (
+    selections: ReadonlyArray<SelectionNode>,
+): Array<SelectionNode> => {
+    const fieldByResponseName = new Map<string, FieldNode>();
+    const orderedNames: Array<string> = [];
+    const passthrough: Array<SelectionNode> = [];
+
+    for (const sel of selections) {
+        if (sel.kind === "Field") {
+            const responseName = sel.alias
+                ? sel.alias.value
+                : sel.name.value;
+            const existing = fieldByResponseName.get(responseName);
+            if (existing) {
+                const existingSels =
+                    existing.selectionSet?.selections ?? [];
+                const newSels = sel.selectionSet?.selections ?? [];
+                const mergedSelectionSet: SelectionSetNode | undefined =
+                    existing.selectionSet || sel.selectionSet
+                        ? {
+                              kind: Kind.SELECTION_SET,
+                              selections: [...existingSels, ...newSels],
+                          }
+                        : undefined;
+                fieldByResponseName.set(responseName, {
+                    ...existing,
+                    selectionSet: mergedSelectionSet,
+                });
+            } else {
+                fieldByResponseName.set(responseName, sel);
+                orderedNames.push(responseName);
+            }
+        } else {
+            passthrough.push(sel);
+        }
+    }
+
+    return [
+        ...orderedNames.map((name) => fieldByResponseName.get(name)!),
+        ...passthrough,
+    ];
+};
+
+// Inline matching InlineFragments and FragmentSpreads into the parent
+// selection list so that Fields appearing on multiple "branches" can be
+// merged by response name in a single pass. Non-matching fragments are
+// preserved so the caller can still emit them or drop them as before.
+const flattenAndMergeSelectionsForType = (
+    ctx: Context,
+    typeName: string,
+    selections: Selections,
+): Array<SelectionNode> => {
+    const flat: Array<SelectionNode> = [];
+    for (const sel of selections) {
+        if (sel.kind === "InlineFragment") {
+            const condName = sel.typeCondition?.name.value ?? typeName;
+            if (condName === typeName) {
+                flat.push(...sel.selectionSet.selections);
+            } else {
+                flat.push(sel);
+            }
+        } else if (sel.kind === "FragmentSpread") {
+            const fragment = ctx.fragments[sel.name.value];
+            if (fragment) {
+                flat.push(...fragment.selectionSet.selections);
+            } else {
+                flat.push(sel);
+            }
+        } else {
+            flat.push(sel);
+        }
+    }
+    return mergeFieldsByResponseName(flat);
+};
+
 export const objectPropertiesToFlow = (
     ctx: Context,
     type: IntrospectionObjectType & {
@@ -252,7 +334,11 @@ export const objectPropertiesToFlow = (
     typeName: string,
     selections: Selections,
 ): Array<babelTypes.TSPropertySignature> => {
-    return selections.flatMap((selection) => {
+    return flattenAndMergeSelectionsForType(
+        ctx,
+        typeName,
+        selections,
+    ).flatMap((selection) => {
         switch (selection.kind) {
             case "InlineFragment": {
                 const newTypeName =
@@ -357,6 +443,54 @@ export const objectPropertiesToFlow = (
     });
 };
 
+// For an interface variant, collect every selection that applies to a given
+// concrete impl: base-level selections, plus the contents of any inline
+// fragment or fragment spread whose type condition matches the impl. The
+// flat list is then handed to objectPropertiesToFlow, whose response-name
+// merge collapses any duplicate Field nodes contributed by different
+// branches (e.g. a base-level `foo { a }` plus an inline-fragment
+// `foo { b }`). Non-matching inline fragments and fragment spreads are
+// dropped.
+const collectInterfaceSelectionsForPossible = (
+    ctx: Context,
+    possibleName: string,
+    selections: Selections,
+): Array<SelectionNode> => {
+    const result: Array<SelectionNode> = [];
+    for (const sel of selections) {
+        if (sel.kind === "InlineFragment") {
+            const condName = sel.typeCondition?.name.value;
+            const matches =
+                !condName ||
+                condName === possibleName ||
+                !!ctx.schema.interfacesByName[condName ?? ""]
+                    ?.possibleTypesByName[possibleName];
+            if (matches) {
+                result.push(...sel.selectionSet.selections);
+            }
+        } else if (sel.kind === "FragmentSpread") {
+            const fragment = ctx.fragments[sel.name.value];
+            if (!fragment) {
+                // Preserve the unknown-fragment error path inside objectPropertiesToFlow.
+                result.push(sel);
+                continue;
+            }
+            const condName = fragment.typeCondition.name.value;
+            const matches =
+                condName === possibleName ||
+                !!ctx.schema.interfacesByName[condName]?.possibleTypesByName[
+                    possibleName
+                ];
+            if (matches) {
+                result.push(...fragment.selectionSet.selections);
+            }
+        } else {
+            result.push(sel);
+        }
+    }
+    return result;
+};
+
 export const unionOrInterfaceToFlow = (
     ctx: Context,
     type:
@@ -371,6 +505,7 @@ export const unionOrInterfaceToFlow = (
     const allFields = selections.every(
         (selection) => selection.kind === "Field",
     );
+    const isUnion = type.kind === "UNION";
     const selectedAttributes: Array<{
         attributes: Array<babelTypes.TSPropertySignature>;
         typeName: string;
@@ -384,20 +519,38 @@ export const unionOrInterfaceToFlow = (
                 ...ctx,
                 path: allFields ? ctx.path : ctx.path.concat([possible.name]),
             };
+            // For interfaces with fragment refinements, flatten matching
+            // fragments into the concrete impl's selection list and let
+            // objectPropertiesToFlow merge duplicates by response name. The
+            // existing per-selection path stays in place for unions (where
+            // base-level Fields are an error and unionOrInterfaceSelection
+            // surfaces it) and for the fragment-free case (where there's
+            // nothing to flatten).
+            const useFlattenedFlow = !isUnion && !allFields;
+            const attributes = useFlattenedFlow
+                ? objectPropertiesToFlow(
+                      configWithUpdatedPath,
+                      ctx.schema.typesByName[possible.name],
+                      possible.name,
+                      collectInterfaceSelectionsForPossible(
+                          ctx,
+                          possible.name,
+                          selections,
+                      ),
+                  )
+                : selections
+                      .map((selection) =>
+                          unionOrInterfaceSelection(
+                              configWithUpdatedPath,
+                              type,
+                              possible,
+                              selection,
+                          ),
+                      )
+                      .flat();
             return {
                 typeName: possible.name,
-                attributes: ensureOnlyOneTypenameProperty(
-                    selections
-                        .map((selection) =>
-                            unionOrInterfaceSelection(
-                                configWithUpdatedPath,
-                                type,
-                                possible,
-                                selection,
-                            ),
-                        )
-                        .flat(),
-                ),
+                attributes: ensureOnlyOneTypenameProperty(attributes),
             };
         });
     // If they're all fields, the only selection that could be different is __typename

--- a/src/generateResponseType.ts
+++ b/src/generateResponseType.ts
@@ -258,13 +258,10 @@ const mergeFieldsByResponseName = (
 
     for (const sel of selections) {
         if (sel.kind === "Field") {
-            const responseName = sel.alias
-                ? sel.alias.value
-                : sel.name.value;
+            const responseName = sel.alias ? sel.alias.value : sel.name.value;
             const existing = fieldByResponseName.get(responseName);
             if (existing) {
-                const existingSels =
-                    existing.selectionSet?.selections ?? [];
+                const existingSels = existing.selectionSet?.selections ?? [];
                 const newSels = sel.selectionSet?.selections ?? [];
                 const mergedSelectionSet: SelectionSetNode | undefined =
                     existing.selectionSet || sel.selectionSet
@@ -334,113 +331,114 @@ export const objectPropertiesToFlow = (
     typeName: string,
     selections: Selections,
 ): Array<babelTypes.TSPropertySignature> => {
-    return flattenAndMergeSelectionsForType(
-        ctx,
-        typeName,
-        selections,
-    ).flatMap((selection) => {
-        switch (selection.kind) {
-            case "InlineFragment": {
-                const newTypeName =
-                    selection.typeCondition?.name.value ?? typeName;
-                if (newTypeName !== typeName) {
-                    return [];
-                }
-                return objectPropertiesToFlow(
-                    ctx,
-                    ctx.schema.typesByName[newTypeName],
-                    newTypeName,
-                    selection.selectionSet.selections,
-                );
-            }
-            case "FragmentSpread":
-                if (!ctx.fragments[selection.name.value]) {
-                    ctx.errors.push(
-                        `No fragment named '${selection.name.value}'. Did you forget to include it in the template literal?`,
+    return flattenAndMergeSelectionsForType(ctx, typeName, selections).flatMap(
+        (selection) => {
+            switch (selection.kind) {
+                case "InlineFragment": {
+                    const newTypeName =
+                        selection.typeCondition?.name.value ?? typeName;
+                    if (newTypeName !== typeName) {
+                        return [];
+                    }
+                    return objectPropertiesToFlow(
+                        ctx,
+                        ctx.schema.typesByName[newTypeName],
+                        newTypeName,
+                        selection.selectionSet.selections,
                     );
-                    return [
-                        babelTypes.tsPropertySignature(
-                            babelTypes.identifier(selection.name.value),
-                            babelTypes.tsTypeAnnotation(
-                                babelTypes.tsTypeReference(
-                                    babelTypes.identifier(`UNKNOWN_FRAGMENT`),
-                                ),
-                            ),
-                        ),
-                    ];
                 }
-
-                return objectPropertiesToFlow(
-                    ctx,
-                    type,
-                    typeName,
-                    ctx.fragments[selection.name.value].selectionSet.selections,
-                );
-
-            case "Field":
-                const name = selection.name.value;
-                const alias: string = selection.alias
-                    ? selection.alias.value
-                    : name;
-                if (name === "__typename") {
-                    return [
-                        babelTypes.tsPropertySignature(
-                            babelTypes.identifier(alias),
-                            babelTypes.tsTypeAnnotation(
-                                babelTypes.tsLiteralType(
-                                    babelTypes.stringLiteral(typeName),
-                                ),
-                            ),
-                        ),
-                    ];
-                }
-                if (!type.fieldsByName[name]) {
-                    ctx.errors.push(
-                        `Unknown field '${name}' for type '${typeName}'`,
-                    );
-                    return [
-                        babelTypes.tsPropertySignature(
-                            babelTypes.identifier(alias),
-                            babelTypes.tsTypeAnnotation(
-                                babelTypes.tsTypeReference(
-                                    babelTypes.identifier(
-                                        `UNKNOWN_FIELD["${name}"]`,
+                case "FragmentSpread":
+                    if (!ctx.fragments[selection.name.value]) {
+                        ctx.errors.push(
+                            `No fragment named '${selection.name.value}'. Did you forget to include it in the template literal?`,
+                        );
+                        return [
+                            babelTypes.tsPropertySignature(
+                                babelTypes.identifier(selection.name.value),
+                                babelTypes.tsTypeAnnotation(
+                                    babelTypes.tsTypeReference(
+                                        babelTypes.identifier(
+                                            `UNKNOWN_FRAGMENT`,
+                                        ),
                                     ),
                                 ),
                             ),
-                        ),
-                    ];
-                }
-                const typeField = type.fieldsByName[name];
+                        ];
+                    }
 
-                return [
-                    maybeAddDescriptionComment(
-                        typeField.description,
-                        liftLeadingPropertyComments(
+                    return objectPropertiesToFlow(
+                        ctx,
+                        type,
+                        typeName,
+                        ctx.fragments[selection.name.value].selectionSet
+                            .selections,
+                    );
+
+                case "Field":
+                    const name = selection.name.value;
+                    const alias: string = selection.alias
+                        ? selection.alias.value
+                        : name;
+                    if (name === "__typename") {
+                        return [
                             babelTypes.tsPropertySignature(
                                 babelTypes.identifier(alias),
                                 babelTypes.tsTypeAnnotation(
-                                    typeToFlow(
-                                        {
-                                            ...ctx,
-                                            path: ctx.path.concat([alias]),
-                                        },
-                                        typeField.type,
-                                        selection,
+                                    babelTypes.tsLiteralType(
+                                        babelTypes.stringLiteral(typeName),
+                                    ),
+                                ),
+                            ),
+                        ];
+                    }
+                    if (!type.fieldsByName[name]) {
+                        ctx.errors.push(
+                            `Unknown field '${name}' for type '${typeName}'`,
+                        );
+                        return [
+                            babelTypes.tsPropertySignature(
+                                babelTypes.identifier(alias),
+                                babelTypes.tsTypeAnnotation(
+                                    babelTypes.tsTypeReference(
+                                        babelTypes.identifier(
+                                            `UNKNOWN_FIELD["${name}"]`,
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ];
+                    }
+                    const typeField = type.fieldsByName[name];
+
+                    return [
+                        maybeAddDescriptionComment(
+                            typeField.description,
+                            liftLeadingPropertyComments(
+                                babelTypes.tsPropertySignature(
+                                    babelTypes.identifier(alias),
+                                    babelTypes.tsTypeAnnotation(
+                                        typeToFlow(
+                                            {
+                                                ...ctx,
+                                                path: ctx.path.concat([alias]),
+                                            },
+                                            typeField.type,
+                                            selection,
+                                        ),
                                     ),
                                 ),
                             ),
                         ),
-                    ),
-                ];
+                    ];
 
-            default:
-                ctx.errors.push(
-                    `Unsupported selection kind '${selection.kind}'`,
-                );
-                return [];
-        }
-    });
+                default:
+                    ctx.errors.push(
+                        `Unsupported selection kind '${selection.kind}'`,
+                    );
+                    return [];
+            }
+        },
+    );
 };
 
 // For an interface variant, collect every selection that applies to a given


### PR DESCRIPTION
## Summary

(For context, I ran into this issue while I was doing some new queries for assignments (which heavily use interfaces). Not a blocker for anything, just a quirk i found)

- **Bug fix:** when the same field is selected at both the base level and inside an inline fragment (or via two fragment spreads), graphql-flow now merges their sub-selections into a single property — mirroring the GraphQL spec's [CollectFields](https://spec.graphql.org/October2021/#CollectFields()) algorithm and what servers actually return. Previously the second occurrence silently clobbered the first, dropping fields from the generated TypeScript.
- **Major version bump:** generated `.ts` output can change for queries that mix inline fragments with base-level selections on an interface. The field-lookup base now follows the concrete impl rather than the interface, so JSDoc descriptions are richer and split-type sub-paths use the field alias (matching how `objectPropertiesToFlow` has always worked for object types).

### Example

Before:

```graphql
hero {
  friends { id }
  ... on Human {
    friends { name }
  }
}
```

The `Human.friends` type was `{ name }` only — `id` was silently dropped.

After: `Human.friends` is `{ id; name }` as the server returns.

### Implementation

- `objectPropertiesToFlow` flattens matching inline fragments and known fragment spreads into the current selection list, then merges Field nodes by response name before generating TS property signatures.
- `unionOrInterfaceToFlow` now routes interface-with-fragments queries through `objectPropertiesToFlow` per concrete impl (with a `collectInterfaceSelectionsForPossible` helper that picks up matching fragment contents), so the same merge fires across base + fragment branches. Unions and the fragment-free case retain the original per-selection flow — confirmed by a new regression test.

### Validation against `khan/frontend`

Ran the local build against `khan/frontend@main` (2,199 resolved queries). 33 files differed (~1.5%):

- Most changes: richer JSDoc descriptions on interface fields (concrete-impl descriptions now flow through). Purely additive.
- 3 sub-type identifier renames in `getNotificationsForUser.ts` where queries alias a field (`classroomInfo: classroom { ... }`). The split-type sub-path now uses the alias, matching object-type behavior. **Zero external references** to the renamed names — invisible to consumers.
- No type signatures lost, no fields disappeared, no nullability flips, no narrowed unions.

## Test plan

- [x] All 50 existing tests pass.
- [x] 4 new regression tests added (object-type merge via inline fragment; object-type merge via fragment spread; interface-with-fragments merge; union-path no-change guard).
- [x] `pnpm typecheck` clean.
- [x] `pnpm build` clean.
- [x] Validated against `khan/frontend@main` — no regressions in 2,199 queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)